### PR TITLE
Fallback to browser Didit flow on Android

### DIFF
--- a/src/app/(app)/(instructor-tabs)/instructor/profile/identity-verification.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/identity-verification.tsx
@@ -52,7 +52,7 @@ const resolveDiditSdkModule = async (): Promise<DiditSdkModule | null> => {
     return cachedDiditSdkModule;
   }
 
-  if (Platform.OS === "web" || Constants.appOwnership === "expo") {
+  if (Platform.OS === "web" || Platform.OS === "android" || Constants.appOwnership === "expo") {
     cachedDiditSdkModule = null;
     return cachedDiditSdkModule;
   }


### PR DESCRIPTION
## Summary
- force Android identity verification to skip the unstable native Didit SDK path
- reuse the existing browser auth-session fallback on Android while preserving iOS native behavior
- keep Expo Go and web behavior unchanged

## Validation
- bun run typecheck
- bunx biome lint \"src/app/(app)/(instructor-tabs)/instructor/profile/identity-verification.tsx\"