### PR TITLE
UI Cut 02: strip home chrome and remove kit buttons from feeds

### DIFF
--- a/src/components/home/home-screen.tsx
+++ b/src/components/home/home-screen.tsx
@@ -8,14 +8,32 @@ import { LoadingScreen } from "@/components/loading-screen";
 import { useUser } from "@/contexts/user-context";
 import { api } from "@/convex/_generated/api";
 import { useBrand } from "@/hooks/use-brand";
-import { buildRoleTabRoute, ROLE_TAB_ROUTE_NAMES } from "@/navigation/role-routes";
+import {
+  buildRoleTabRoute,
+  ROLE_TAB_ROUTE_NAMES,
+} from "@/navigation/role-routes";
 
 const HOME_STUDIO_JOBS_LIMIT = 36;
-const INSTRUCTOR_JOBS_ROUTE = buildRoleTabRoute("instructor", ROLE_TAB_ROUTE_NAMES.jobs);
-const INSTRUCTOR_PROFILE_ROUTE = buildRoleTabRoute("instructor", ROLE_TAB_ROUTE_NAMES.profile);
-const STUDIO_JOBS_ROUTE = buildRoleTabRoute("studio", ROLE_TAB_ROUTE_NAMES.jobs);
-const STUDIO_CALENDAR_ROUTE = buildRoleTabRoute("studio", ROLE_TAB_ROUTE_NAMES.calendar);
-const STUDIO_PROFILE_ROUTE = buildRoleTabRoute("studio", ROLE_TAB_ROUTE_NAMES.profile);
+const INSTRUCTOR_JOBS_ROUTE = buildRoleTabRoute(
+  "instructor",
+  ROLE_TAB_ROUTE_NAMES.jobs,
+);
+const INSTRUCTOR_PROFILE_ROUTE = buildRoleTabRoute(
+  "instructor",
+  ROLE_TAB_ROUTE_NAMES.profile,
+);
+const STUDIO_JOBS_ROUTE = buildRoleTabRoute(
+  "studio",
+  ROLE_TAB_ROUTE_NAMES.jobs,
+);
+const STUDIO_CALENDAR_ROUTE = buildRoleTabRoute(
+  "studio",
+  ROLE_TAB_ROUTE_NAMES.calendar,
+);
+const STUDIO_PROFILE_ROUTE = buildRoleTabRoute(
+  "studio",
+  ROLE_TAB_ROUTE_NAMES.profile,
+);
 
 export default function HomeScreen() {
   const { t, i18n } = useTranslation();
@@ -27,7 +45,8 @@ export default function HomeScreen() {
   const { currentUser, isAuthLoading, isAuthenticated } = useUser();
   const canQueryInstructor =
     !isAuthLoading && isAuthenticated && currentUser?.role === "instructor";
-  const canQueryStudio = !isAuthLoading && isAuthenticated && currentUser?.role === "studio";
+  const canQueryStudio =
+    !isAuthLoading && isAuthenticated && currentUser?.role === "studio";
 
   // Role-specific queries - only fetch when user role is known
   const myStudioJobs = useQuery(
@@ -44,7 +63,10 @@ export default function HomeScreen() {
     canQueryInstructor ? {} : "skip",
   );
 
-  const studioSettings = useQuery(api.users.getMyStudioSettings, canQueryStudio ? {} : "skip");
+  const studioSettings = useQuery(
+    api.users.getMyStudioSettings,
+    canQueryStudio ? {} : "skip",
+  );
 
   const currencyFormatter = useMemo(
     () =>
@@ -72,7 +94,10 @@ export default function HomeScreen() {
     return <Redirect href="/sign-in" />;
   }
 
-  if (currentUser && (!currentUser.onboardingComplete || currentUser.role === "pending")) {
+  if (
+    currentUser &&
+    (!currentUser.onboardingComplete || currentUser.role === "pending")
+  ) {
     return <Redirect href="/onboarding" />;
   }
 
@@ -95,12 +120,16 @@ export default function HomeScreen() {
       ?.trim()
       .split(/\s+/)[0];
     const displayName =
-      firstName && firstName.length > 0 ? firstName : t("home.shared.unknownName");
+      firstName && firstName.length > 0
+        ? firstName
+        : t("home.shared.unknownName");
 
     return (
       <InstructorHomeContent
         displayName={displayName}
-        profileImageUrl={instructorSettings?.profileImageUrl ?? currentUser.image}
+        profileImageUrl={
+          instructorSettings?.profileImageUrl ?? currentUser.image
+        }
         isVerified={instructorHomeStats.isVerified}
         locale={locale}
         openMatches={instructorHomeStats.openMatches}
@@ -108,8 +137,6 @@ export default function HomeScreen() {
         palette={palette}
         currencyFormatter={currencyFormatter}
         t={t}
-        earningsEvents={instructorHomeStats.earningsEvents}
-        lessonEvents={instructorHomeStats.lessonEvents}
         upcomingSessions={instructorHomeStats.upcomingSessions}
         onOpenJobs={() => router.push(INSTRUCTOR_JOBS_ROUTE)}
         onOpenProfile={() => router.push(INSTRUCTOR_PROFILE_ROUTE)}
@@ -122,14 +149,23 @@ export default function HomeScreen() {
   }
 
   const studioJobs = myStudioJobs ?? [];
-  const openJobs = studioJobs.filter((job: any) => job.status === "open").length;
+  const openJobs = studioJobs.filter(
+    (job: any) => job.status === "open",
+  ).length;
   const pendingApplicants = studioJobs.reduce(
     (total: number, job: any) => total + job.pendingApplicationsCount,
     0,
   );
-  const jobsFilled = studioJobs.filter((job: any) => job.status === "filled").length;
-  const firstName = (studioSettings?.studioName ?? currentUser.fullName)?.trim().split(/\s+/)[0];
-  const displayName = firstName && firstName.length > 0 ? firstName : t("home.shared.unknownName");
+  const jobsFilled = studioJobs.filter(
+    (job: any) => job.status === "filled",
+  ).length;
+  const firstName = (studioSettings?.studioName ?? currentUser.fullName)
+    ?.trim()
+    .split(/\s+/)[0];
+  const displayName =
+    firstName && firstName.length > 0
+      ? firstName
+      : t("home.shared.unknownName");
 
   return (
     <StudioHomeContent

--- a/src/components/home/instructor-home-content.tsx
+++ b/src/components/home/instructor-home-content.tsx
@@ -1,7 +1,11 @@
 import type { TFunction } from "i18next";
 import { useMemo } from "react";
-import { Text, View } from "react-native";
-import Animated, { FadeInUp, useAnimatedRef, useScrollViewOffset } from "react-native-reanimated";
+import { Pressable, Text, View } from "react-native";
+import Animated, {
+  FadeInUp,
+  useAnimatedRef,
+  useScrollViewOffset,
+} from "react-native-reanimated";
 
 import {
   HomeSectionHeading,
@@ -13,19 +17,7 @@ import {
   HomeHeaderSheet,
 } from "@/components/home/home-header-sheet";
 import { getRelativeTimeLabel } from "@/components/home/home-shared";
-import { HomeStatsRow } from "@/components/home/home-stats-row";
-import {
-  getTimeframeData,
-  type MetricMode,
-  type Timeframe,
-} from "@/components/home/performance-chart-math";
-import {
-  PerformanceHeroCard,
-  type PerformanceTimeframeSeries,
-} from "@/components/home/performance-hero-card";
-import { usePerformanceChart } from "@/components/home/use-performance-chart";
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
-import { KitButton } from "@/components/ui/kit";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandSpacing, BrandType } from "@/constants/brand";
 import { getZoneLabel } from "@/constants/zones";
@@ -42,15 +34,6 @@ type UpcomingSession = {
   pay: number;
 };
 
-type InstructorPaymentRow = {
-  timestamp: number;
-  amountAgorot: number;
-};
-
-type InstructorApplicationRow = {
-  endTime: number;
-};
-
 type InstructorHomeContentProps = {
   displayName: string;
   profileImageUrl?: string | null | undefined;
@@ -61,8 +44,6 @@ type InstructorHomeContentProps = {
   palette: BrandPalette;
   currencyFormatter: Intl.NumberFormat;
   t: TFunction;
-  earningsEvents: InstructorPaymentRow[];
-  lessonEvents: InstructorApplicationRow[];
   upcomingSessions: UpcomingSession[];
 
   onOpenJobs: () => void;
@@ -79,8 +60,6 @@ export function InstructorHomeContent({
   palette,
   currencyFormatter,
   t,
-  earningsEvents,
-  lessonEvents,
   upcomingSessions,
   onOpenJobs,
   onOpenProfile,
@@ -91,58 +70,6 @@ export function InstructorHomeContent({
   const layout = useHomeDashboardLayout();
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollY = useScrollViewOffset(scrollRef);
-
-  const computeSeries = useMemo(() => {
-    return (currentMetricMode: MetricMode) => {
-      const frames = {} as Record<Timeframe, PerformanceTimeframeSeries>;
-
-      (["weekly", "monthly", "yearly"] as const).forEach((frame) => {
-        const frameData = getTimeframeData(frame, now, locale);
-        const values = Array.from({ length: frameData.bucketStarts.length }, () => 0);
-
-        if (currentMetricMode === "earnings") {
-          for (const row of earningsEvents) {
-            for (let index = 0; index < frameData.bucketStarts.length; index += 1) {
-              const bucketStart = frameData.bucketStarts[index]!;
-              const bucketEnd = frameData.bucketEnds[index]!;
-              if (row.timestamp >= bucketStart && row.timestamp < bucketEnd) {
-                values[index] = (values[index] ?? 0) + row.amountAgorot;
-                break;
-              }
-            }
-          }
-        } else {
-          for (const row of lessonEvents) {
-            for (let index = 0; index < frameData.bucketStarts.length; index += 1) {
-              const bucketStart = frameData.bucketStarts[index]!;
-              const bucketEnd = frameData.bucketEnds[index]!;
-              if (row.endTime >= bucketStart && row.endTime < bucketEnd) {
-                values[index] = (values[index] ?? 0) + 1;
-                break;
-              }
-            }
-          }
-        }
-
-        frames[frame] = {
-          values,
-          axisTicks: frameData.axisTicks,
-        };
-      });
-
-      return frames;
-    };
-  }, [earningsEvents, lessonEvents, locale, now]);
-
-  const chart = usePerformanceChart({
-    computeSeries,
-    currencyFormatter,
-    metricLabels: {
-      earnings: t("home.performance.earnings", { defaultValue: "Earnings" }),
-      lessons: t("home.performance.lessonLabel", { defaultValue: "Lessons" }),
-    },
-    t,
-  });
 
   const nextSession = upcomingSessions[0] ?? null;
   const readinessLabel = isVerified
@@ -160,7 +87,9 @@ export function InstructorHomeContent({
       });
   const heroSecondaryLabel =
     pendingApplications > 0
-      ? t("home.instructor.pendingApps", { defaultValue: "Pending applications" })
+      ? t("home.instructor.pendingApps", {
+          defaultValue: "Pending applications",
+        })
       : t("home.instructor.readyState", { defaultValue: "Ready state" });
   const heroSecondaryValue =
     pendingApplications > 0
@@ -171,10 +100,17 @@ export function InstructorHomeContent({
       : nextSession
         ? getRelativeTimeLabel(nextSession.startTime, now, locale)
         : t("home.instructor.profileSet", { defaultValue: "Profile set" });
+  const leadAction = !isVerified ? onOpenProfile : onOpenJobs;
+  const leadActionHint = !isVerified
+    ? t("home.actions.profileTitle", { defaultValue: "Open profile" })
+    : t("home.actions.jobsTitle", { defaultValue: "Open jobs" });
   const visibleSessions = upcomingSessions.slice(0, layout.isWideWeb ? 6 : 4);
 
   return (
-    <View collapsable={false} style={{ flex: 1, backgroundColor: palette.appBg }}>
+    <View
+      collapsable={false}
+      style={{ flex: 1, backgroundColor: palette.appBg }}
+    >
       <HomeHeaderSheet
         displayName={displayName}
         subtitle={readinessLabel}
@@ -193,33 +129,28 @@ export function InstructorHomeContent({
           paddingHorizontal: BrandSpacing.xl,
           paddingTop: getHomeHeaderScrollTopPadding(safeTop),
           paddingBottom: BrandSpacing.xxl,
-          gap: layout.sectionGap,
+          gap: BrandSpacing.xl,
         }}
       >
-        <View
-          style={{
-            flexDirection: layout.isWideWeb ? "row" : "column",
-            alignItems: "stretch",
-            gap: layout.topRowGap,
-          }}
-        >
-          <Animated.View
-            entering={FadeInUp.delay(80).duration(300)}
-            style={{ flex: layout.heroFlex, gap: layout.sectionGap }}
+        <Animated.View entering={FadeInUp.delay(80).duration(280)}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={leadActionHint}
+            onPress={leadAction}
+            style={({ pressed }) => ({
+              opacity: pressed ? 0.94 : 1,
+              transform: [{ scale: pressed ? 0.995 : 1 }],
+            })}
           >
-            {/* Collapsed Hero Card */}
             <HomeSurface
               palette={palette}
+              tone="surface"
               style={{
-                padding: BrandSpacing.lg,
-                flexDirection: "row",
-                alignItems: "center",
-                justifyContent: "space-between",
+                padding: BrandSpacing.xl,
                 gap: BrandSpacing.md,
-                minHeight: layout.railMinHeight,
               }}
             >
-              <View style={{ flex: 1, gap: 4 }}>
+              <View style={{ gap: 6 }}>
                 <Text
                   style={{
                     ...BrandType.micro,
@@ -228,93 +159,99 @@ export function InstructorHomeContent({
                   }}
                 >
                   {nextSession
-                    ? t("home.instructor.eyebrowNext", { defaultValue: "NEXT LESSON" })
-                    : t("home.instructor.eyebrowBoard", { defaultValue: "JOBS BOARD" })}
+                    ? t("home.instructor.eyebrowNext", {
+                        defaultValue: "NEXT LESSON",
+                      })
+                    : t("home.instructor.eyebrowBoard", {
+                        defaultValue: "JOBS BOARD",
+                      })}
                 </Text>
                 <Text
                   style={{
                     ...BrandType.heading,
-                    fontSize: 20,
+                    fontSize: layout.isWideWeb ? 30 : 24,
+                    lineHeight: layout.isWideWeb ? 32 : 26,
                     color: palette.text as string,
                   }}
-                  numberOfLines={1}
                 >
                   {heroTitle}
                 </Text>
+                <Text
+                  style={{
+                    ...BrandType.body,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  {nextSession
+                    ? [
+                        formatDateTime(nextSession.startTime, locale),
+                        getZoneLabel(nextSession.zone, zoneLanguage),
+                      ].join("  ·  ")
+                    : t("home.instructor.heroMatches", {
+                        count: openMatches,
+                        defaultValue: `${String(openMatches)} open matches near you`,
+                      })}
+                </Text>
               </View>
-              <KitButton
-                label={
-                  nextSession
-                    ? t("home.actions.profileTitle", { defaultValue: "Profile" })
-                    : t("home.actions.jobsTitle", { defaultValue: "Open Jobs" })
-                }
-                onPress={nextSession ? onOpenProfile : onOpenJobs}
-                size="sm"
-              />
+
+              <View
+                style={{
+                  flexDirection: layout.isWideWeb ? "row" : "column",
+                  alignItems: layout.isWideWeb ? "center" : "stretch",
+                  justifyContent: "space-between",
+                  gap: BrandSpacing.md,
+                }}
+              >
+                <Text
+                  style={{
+                    ...BrandType.bodyStrong,
+                    color: palette.primary as string,
+                  }}
+                >
+                  {`${heroSecondaryLabel}: ${heroSecondaryValue}`}
+                </Text>
+                <Text
+                  style={{
+                    ...BrandType.micro,
+                    color: palette.textMuted as string,
+                    textTransform: "uppercase",
+                    letterSpacing: 0.6,
+                  }}
+                >
+                  {leadActionHint}
+                </Text>
+              </View>
             </HomeSurface>
+          </Pressable>
+        </Animated.View>
 
-            <HomeStatsRow
-              palette={palette}
-              stats={[
-                {
-                  icon: "briefcase.fill",
-                  label: t("jobsTab.title", { defaultValue: "Open matches" }),
-                  value: String(openMatches),
-                },
-                {
-                  icon: "clock.fill",
-                  label: t("home.shared.pending"),
-                  value: String(pendingApplications),
-                },
-                {
-                  icon:
-                    pendingApplications > 0
-                      ? "clock.fill"
-                      : nextSession
-                        ? "calendar.badge.clock"
-                        : "checkmark.circle.fill",
-                  label: heroSecondaryLabel,
-                  value: heroSecondaryValue,
-                },
-              ]}
-            />
-          </Animated.View>
-
-          <Animated.View
-            entering={FadeInUp.delay(120).duration(320)}
-            style={{ flex: layout.chartFlex }}
-          >
-            <PerformanceHeroCard
-              palette={palette}
-              timeframe={chart.timeframe}
-              metricMode={chart.metricMode}
-              timeframeLabel={chart.timeframeLabel}
-              insightLabel={chart.insightLabel}
-              totalLabel={chart.summaryValue}
-              metricOptions={chart.metricOptions}
-              timeframeOptions={chart.timeframeOptions}
-              seriesByTimeframe={chart.seriesByTimeframe}
-              onSelectMetric={chart.setMetricMode}
-              onSelectTimeframe={chart.setTimeframe}
-              onSwipeTimeframe={chart.handleSwipeTimeframe}
-            />
-          </Animated.View>
-        </View>
-
-        <Animated.View entering={FadeInUp.delay(180).duration(320)} style={{ gap: 12 }}>
+        <Animated.View
+          entering={FadeInUp.delay(180).duration(320)}
+          style={{ gap: 12 }}
+        >
           <HomeSectionHeading
             title={t("home.instructor.nextTitle")}
-            eyebrow={t("home.instructor.scheduleEyebrow", { defaultValue: "SCHEDULE" })}
+            eyebrow={t("home.instructor.scheduleEyebrow", {
+              defaultValue: "SCHEDULE",
+            })}
             palette={palette}
           />
           {upcomingSessions.length === 0 ? (
             <HomeSurface palette={palette} style={{ padding: 18, gap: 6 }}>
-              <Text style={{ ...BrandType.title, color: palette.text as string }}>
+              <Text
+                style={{ ...BrandType.title, color: palette.text as string }}
+              >
                 {t("home.instructor.noUpcoming")}
               </Text>
-              <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+              <Text
+                style={{
+                  ...BrandType.caption,
+                  color: palette.textMuted as string,
+                }}
+              >
                 {t("home.instructor.emptySchedule", {
-                  defaultValue: "The jobs board is live when you want the next one.",
+                  defaultValue:
+                    "The jobs board is live when you want the next one.",
                 })}
               </Text>
             </HomeSurface>
@@ -361,12 +298,20 @@ export function InstructorHomeContent({
                           fontVariant: ["tabular-nums"],
                         }}
                       >
-                        {new Date(session.startTime).toLocaleTimeString(locale, {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
+                        {new Date(session.startTime).toLocaleTimeString(
+                          locale,
+                          {
+                            hour: "2-digit",
+                            minute: "2-digit",
+                          },
+                        )}
                       </Text>
-                      <Text style={{ ...BrandType.micro, color: palette.textMuted as string }}>
+                      <Text
+                        style={{
+                          ...BrandType.micro,
+                          color: palette.textMuted as string,
+                        }}
+                      >
                         {getRelativeTimeLabel(session.startTime, now, locale)}
                       </Text>
                     </View>
@@ -381,13 +326,19 @@ export function InstructorHomeContent({
                       >
                         <View style={{ flex: 1, gap: 2 }}>
                           <Text
-                            style={{ ...BrandType.title, color: palette.text as string }}
+                            style={{
+                              ...BrandType.title,
+                              color: palette.text as string,
+                            }}
                             numberOfLines={1}
                           >
                             {toSportLabel(session.sport as never)}
                           </Text>
                           <Text
-                            style={{ ...BrandType.micro, color: palette.primary as string }}
+                            style={{
+                              ...BrandType.micro,
+                              color: palette.primary as string,
+                            }}
                             numberOfLines={1}
                           >
                             {session.studioName}
@@ -404,7 +355,12 @@ export function InstructorHomeContent({
                           {currencyFormatter.format(session.pay)}
                         </Text>
                       </View>
-                      <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+                      <Text
+                        style={{
+                          ...BrandType.caption,
+                          color: palette.textMuted as string,
+                        }}
+                      >
                         {[
                           formatDateTime(session.startTime, locale),
                           getZoneLabel(session.zone, zoneLanguage),

--- a/src/components/home/studio-home-content.tsx
+++ b/src/components/home/studio-home-content.tsx
@@ -1,7 +1,10 @@
 import type { TFunction } from "i18next";
-import { useMemo } from "react";
-import { Text, View } from "react-native";
-import Animated, { FadeInUp, useAnimatedRef, useScrollViewOffset } from "react-native-reanimated";
+import { Pressable, Text, View } from "react-native";
+import Animated, {
+  FadeInUp,
+  useAnimatedRef,
+  useScrollViewOffset,
+} from "react-native-reanimated";
 
 import {
   HomeSectionHeading,
@@ -12,19 +15,7 @@ import {
   getHomeHeaderScrollTopPadding,
   HomeHeaderSheet,
 } from "@/components/home/home-header-sheet";
-import { HomeStatsRow } from "@/components/home/home-stats-row";
-import {
-  getTimeframeData,
-  type MetricMode,
-  type Timeframe,
-} from "@/components/home/performance-chart-math";
-import {
-  PerformanceHeroCard,
-  type PerformanceTimeframeSeries,
-} from "@/components/home/performance-hero-card";
-import { usePerformanceChart } from "@/components/home/use-performance-chart";
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
-import { KitButton, KitPressable } from "@/components/ui/kit";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandSpacing, BrandType } from "@/constants/brand";
 import { getZoneLabel } from "@/constants/zones";
@@ -82,57 +73,6 @@ export function StudioHomeContent({
     .slice(0, 4);
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollY = useScrollViewOffset(scrollRef);
-  const now = useMemo(() => Date.now(), []);
-
-  const computeSeries = useMemo(() => {
-    return (currentMetricMode: MetricMode) => {
-      const frames = {} as Record<Timeframe, PerformanceTimeframeSeries>;
-
-      (["weekly", "monthly", "yearly"] as const).forEach((frame) => {
-        const frameData = getTimeframeData(frame, now, locale);
-        const values = Array.from({ length: frameData.bucketStarts.length }, () => 0);
-
-        for (const row of recentJobs) {
-          const metricValue =
-            currentMetricMode === "earnings"
-              ? row.status === "cancelled"
-                ? 0
-                : row.pay * 100
-              : row.status === "completed"
-                ? 1
-                : 0;
-          if (metricValue === 0) continue;
-
-          const metricTime = currentMetricMode === "earnings" ? row.startTime : row.endTime;
-          for (let index = 0; index < frameData.bucketStarts.length; index += 1) {
-            const bucketStart = frameData.bucketStarts[index]!;
-            const bucketEnd = frameData.bucketEnds[index]!;
-            if (metricTime >= bucketStart && metricTime < bucketEnd) {
-              values[index] = (values[index] ?? 0) + metricValue;
-              break;
-            }
-          }
-        }
-
-        frames[frame] = {
-          values,
-          axisTicks: frameData.axisTicks,
-        };
-      });
-
-      return frames;
-    };
-  }, [recentJobs, locale, now]);
-
-  const chart = usePerformanceChart({
-    computeSeries,
-    currencyFormatter,
-    metricLabels: {
-      earnings: t("home.performance.spend", { defaultValue: "Spend" }),
-      lessons: t("home.performance.sessions", { defaultValue: "Sessions" }),
-    },
-    t,
-  });
 
   const heroTitle =
     jobsNeedingReview.length > 0
@@ -144,7 +84,9 @@ export function StudioHomeContent({
 
   const heroSecondaryLabel =
     jobsNeedingReview.length > 0
-      ? t("home.studio.pendingApplicants", { defaultValue: "Pending applicants" })
+      ? t("home.studio.pendingApplicants", {
+          defaultValue: "Pending applicants",
+        })
       : t("home.studio.recentlyFilled", { defaultValue: "Recently filled" });
 
   const heroSecondaryValue =
@@ -157,11 +99,19 @@ export function StudioHomeContent({
           count: jobsFilled,
           defaultValue: `${String(jobsFilled)} closed`,
         });
+  const leadAction = jobsNeedingReview.length > 0 ? onOpenJobs : onOpenCalendar;
+  const leadActionHint =
+    jobsNeedingReview.length > 0
+      ? t("home.actions.jobsTitle", { defaultValue: "Open jobs" })
+      : t("home.actions.calendarTitle", { defaultValue: "Open calendar" });
 
   const visibleRecentJobs = recentJobs.slice(0, layout.isWideWeb ? 6 : 4);
 
   return (
-    <View collapsable={false} style={{ flex: 1, backgroundColor: palette.appBg }}>
+    <View
+      collapsable={false}
+      style={{ flex: 1, backgroundColor: palette.appBg }}
+    >
       <HomeHeaderSheet
         displayName={displayName}
         subtitle={t("home.studio.role", { defaultValue: "Studio" })}
@@ -179,33 +129,28 @@ export function StudioHomeContent({
           paddingHorizontal: BrandSpacing.xl,
           paddingTop: getHomeHeaderScrollTopPadding(safeTop),
           paddingBottom: BrandSpacing.xxl,
-          gap: layout.sectionGap,
+          gap: BrandSpacing.xl,
         }}
       >
-        <View
-          style={{
-            flexDirection: layout.isWideWeb ? "row" : "column",
-            alignItems: "stretch",
-            gap: layout.topRowGap,
-          }}
-        >
-          <Animated.View
-            entering={FadeInUp.delay(80).duration(300)}
-            style={{ flex: layout.heroFlex, gap: layout.sectionGap }}
+        <Animated.View entering={FadeInUp.delay(80).duration(280)}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={leadActionHint}
+            onPress={leadAction}
+            style={({ pressed }) => ({
+              opacity: pressed ? 0.94 : 1,
+              transform: [{ scale: pressed ? 0.995 : 1 }],
+            })}
           >
-            {/* Collapsed Hero Card */}
             <HomeSurface
               palette={palette}
+              tone="surface"
               style={{
-                padding: BrandSpacing.lg,
-                flexDirection: "row",
-                alignItems: "center",
-                justifyContent: "space-between",
+                padding: BrandSpacing.xl,
                 gap: BrandSpacing.md,
-                minHeight: layout.railMinHeight,
               }}
             >
-              <View style={{ flex: 1, gap: 4 }}>
+              <View style={{ gap: 6 }}>
                 <Text
                   style={{
                     ...BrandType.micro,
@@ -214,77 +159,78 @@ export function StudioHomeContent({
                   }}
                 >
                   {jobsNeedingReview.length > 0
-                    ? t("home.studio.eyebrowReview", { defaultValue: "REVIEW QUEUE" })
-                    : t("home.studio.eyebrowOps", { defaultValue: "OPERATIONS" })}
+                    ? t("home.studio.eyebrowReview", {
+                        defaultValue: "REVIEW QUEUE",
+                      })
+                    : t("home.studio.eyebrowOps", {
+                        defaultValue: "OPERATIONS",
+                      })}
                 </Text>
                 <Text
                   style={{
                     ...BrandType.heading,
-                    fontSize: 20,
+                    fontSize: layout.isWideWeb ? 30 : 24,
+                    lineHeight: layout.isWideWeb ? 32 : 26,
                     color: palette.text as string,
                   }}
-                  numberOfLines={1}
                 >
                   {heroTitle}
                 </Text>
+                <Text
+                  style={{
+                    ...BrandType.body,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  {jobsNeedingReview.length > 0
+                    ? t("home.studio.waitingCount", {
+                        count: pendingApplicants,
+                        defaultValue: `${String(pendingApplicants)} waiting`,
+                      })
+                    : t("home.studio.heroActive", {
+                        count: openJobs,
+                        defaultValue: `${String(openJobs)} active jobs on the board`,
+                      })}
+                </Text>
               </View>
-              <KitButton
-                label={
-                  jobsNeedingReview.length > 0
-                    ? t("home.actions.jobsTitle", { defaultValue: "Open Jobs" })
-                    : t("home.actions.calendarTitle", { defaultValue: "Calendar" })
-                }
-                onPress={jobsNeedingReview.length > 0 ? onOpenJobs : onOpenCalendar}
-                size="sm"
-              />
+
+              <View
+                style={{
+                  flexDirection: layout.isWideWeb ? "row" : "column",
+                  alignItems: layout.isWideWeb ? "center" : "stretch",
+                  justifyContent: "space-between",
+                  gap: BrandSpacing.md,
+                }}
+              >
+                <Text
+                  style={{
+                    ...BrandType.bodyStrong,
+                    color: palette.primary as string,
+                  }}
+                >
+                  {`${heroSecondaryLabel}: ${heroSecondaryValue}`}
+                </Text>
+                <Text
+                  style={{
+                    ...BrandType.micro,
+                    color: palette.textMuted as string,
+                    textTransform: "uppercase",
+                    letterSpacing: 0.6,
+                  }}
+                >
+                  {leadActionHint}
+                </Text>
+              </View>
             </HomeSurface>
-
-            <HomeStatsRow
-              palette={palette}
-              stats={[
-                {
-                  icon: "briefcase.fill",
-                  label: t("jobsTab.title", { defaultValue: "Open jobs" }),
-                  value: String(openJobs),
-                },
-                {
-                  icon: "clock.fill",
-                  label: t("home.shared.pending"),
-                  value: String(pendingApplicants),
-                },
-                {
-                  icon: jobsNeedingReview.length > 0 ? "clock.fill" : "checkmark.circle.fill",
-                  label: heroSecondaryLabel,
-                  value: heroSecondaryValue,
-                },
-              ]}
-            />
-          </Animated.View>
-
-          <Animated.View
-            entering={FadeInUp.delay(120).duration(320)}
-            style={{ flex: layout.chartFlex }}
-          >
-            <PerformanceHeroCard
-              palette={palette}
-              timeframe={chart.timeframe}
-              metricMode={chart.metricMode}
-              timeframeLabel={chart.timeframeLabel}
-              insightLabel={chart.insightLabel}
-              totalLabel={chart.summaryValue}
-              metricOptions={chart.metricOptions}
-              timeframeOptions={chart.timeframeOptions}
-              seriesByTimeframe={chart.seriesByTimeframe}
-              onSelectMetric={chart.setMetricMode}
-              onSelectTimeframe={chart.setTimeframe}
-              onSwipeTimeframe={chart.handleSwipeTimeframe}
-            />
-          </Animated.View>
-        </View>
+          </Pressable>
+        </Animated.View>
 
         <View
           style={{
-            flexDirection: layout.isWideWeb && jobsNeedingReview.length > 0 ? "row" : "column",
+            flexDirection:
+              layout.isWideWeb && jobsNeedingReview.length > 0
+                ? "row"
+                : "column",
             alignItems: "stretch",
             gap: layout.sectionGap,
           }}
@@ -295,8 +241,12 @@ export function StudioHomeContent({
               style={{ flex: layout.isWideWeb ? 1.08 : undefined, gap: 12 }}
             >
               <HomeSectionHeading
-                title={t("home.studio.needsReview", { defaultValue: "Needs review" })}
-                eyebrow={t("home.studio.queueEyebrow", { defaultValue: "QUEUE" })}
+                title={t("home.studio.needsReview", {
+                  defaultValue: "Needs review",
+                })}
+                eyebrow={t("home.studio.queueEyebrow", {
+                  defaultValue: "QUEUE",
+                })}
                 palette={palette}
               />
               <View style={{ gap: 10 }}>
@@ -308,10 +258,13 @@ export function StudioHomeContent({
                       .springify()
                       .damping(18)}
                   >
-                    <KitPressable
+                    <Pressable
                       accessibilityRole="button"
                       accessibilityLabel={t("home.actions.jobsTitle")}
                       onPress={onOpenJobs}
+                      style={({ pressed }) => ({
+                        opacity: pressed ? 0.94 : 1,
+                      })}
                     >
                       <HomeSurface palette={palette} style={{ padding: 16 }}>
                         <View
@@ -323,11 +276,19 @@ export function StudioHomeContent({
                           }}
                         >
                           <View style={{ flex: 1, gap: 3 }}>
-                            <Text style={{ ...BrandType.title, color: palette.text as string }}>
+                            <Text
+                              style={{
+                                ...BrandType.title,
+                                color: palette.text as string,
+                              }}
+                            >
                               {toSportLabel(job.sport as never)}
                             </Text>
                             <Text
-                              style={{ ...BrandType.caption, color: palette.textMuted as string }}
+                              style={{
+                                ...BrandType.caption,
+                                color: palette.textMuted as string,
+                              }}
                             >
                               {[
                                 formatDateTime(job.startTime, locale),
@@ -349,7 +310,7 @@ export function StudioHomeContent({
                           </Text>
                         </View>
                       </HomeSurface>
-                    </KitPressable>
+                    </Pressable>
                   </Animated.View>
                 ))}
               </View>
@@ -357,25 +318,40 @@ export function StudioHomeContent({
           ) : null}
 
           <Animated.View
-            entering={FadeInUp.delay(jobsNeedingReview.length > 0 ? 220 : 180).duration(320)}
+            entering={FadeInUp.delay(
+              jobsNeedingReview.length > 0 ? 220 : 180,
+            ).duration(320)}
             style={{
-              flex: layout.isWideWeb && jobsNeedingReview.length > 0 ? 0.92 : undefined,
+              flex:
+                layout.isWideWeb && jobsNeedingReview.length > 0
+                  ? 0.92
+                  : undefined,
               gap: 12,
             }}
           >
             <HomeSectionHeading
               title={t("home.studio.recentTitle")}
-              eyebrow={t("home.studio.boardEyebrow", { defaultValue: "LIVE BOARD" })}
+              eyebrow={t("home.studio.boardEyebrow", {
+                defaultValue: "LIVE BOARD",
+              })}
               palette={palette}
             />
             {recentJobs.length === 0 ? (
               <HomeSurface palette={palette} style={{ padding: 18, gap: 6 }}>
-                <Text style={{ ...BrandType.title, color: palette.text as string }}>
+                <Text
+                  style={{ ...BrandType.title, color: palette.text as string }}
+                >
                   {t("home.studio.noRecent")}
                 </Text>
-                <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
                   {t("home.studio.emptyBoard", {
-                    defaultValue: "Post a shift to start filling your schedule.",
+                    defaultValue:
+                      "Post a shift to start filling your schedule.",
                   })}
                 </Text>
               </HomeSurface>
@@ -389,7 +365,10 @@ export function StudioHomeContent({
                       .springify()
                       .damping(18)}
                   >
-                    <HomeSurface palette={palette} style={{ padding: 16, gap: 4 }}>
+                    <HomeSurface
+                      palette={palette}
+                      style={{ padding: 16, gap: 4 }}
+                    >
                       <View
                         style={{
                           flexDirection: "row",
@@ -399,11 +378,19 @@ export function StudioHomeContent({
                         }}
                       >
                         <View style={{ flex: 1, gap: 2 }}>
-                          <Text style={{ ...BrandType.title, color: palette.text as string }}>
+                          <Text
+                            style={{
+                              ...BrandType.title,
+                              color: palette.text as string,
+                            }}
+                          >
                             {toSportLabel(job.sport as never)}
                           </Text>
                           <Text
-                            style={{ ...BrandType.caption, color: palette.textMuted as string }}
+                            style={{
+                              ...BrandType.caption,
+                              color: palette.textMuted as string,
+                            }}
                           >
                             {[
                               formatDateTime(job.startTime, locale),

--- a/src/components/jobs/instructor/instructor-open-jobs-list.tsx
+++ b/src/components/jobs/instructor/instructor-open-jobs-list.tsx
@@ -2,9 +2,15 @@ import type { TFunction } from "i18next";
 import { Text, View } from "react-native";
 import Animated, { FadeInUp } from "react-native-reanimated";
 import { DotStatusPill, MetricCell } from "@/components/home/home-shared";
-import { KitButton, KitSurface } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
+import { KitSurface } from "@/components/ui/kit";
 import { ProfileAvatar } from "@/components/ui/profile-avatar";
-import { type BrandPalette, BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
+import {
+  type BrandPalette,
+  BrandRadius,
+  BrandSpacing,
+  BrandType,
+} from "@/constants/brand";
 import { getZoneLabel } from "@/constants/zones";
 import type { Id } from "@/convex/_generated/dataModel";
 import { toSportLabel } from "@/convex/constants";
@@ -69,9 +75,13 @@ export function InstructorOpenJobsList({
       }}
     >
       {jobs.map((job, index) => {
-        const tone = job.applicationStatus ? STATUS_DOT[job.applicationStatus] : null;
+        const tone = job.applicationStatus
+          ? STATUS_DOT[job.applicationStatus]
+          : null;
         const dotColor = tone ? (palette[tone.color] as string) : undefined;
-        const pillBackground = tone ? (palette[tone.background] as string) : undefined;
+        const pillBackground = tone
+          ? (palette[tone.background] as string)
+          : undefined;
         const shiftWindow = `${formatDateWithWeekday(job.startTime, locale)} · ${formatTime(
           job.startTime,
           locale,
@@ -124,7 +134,9 @@ export function InstructorOpenJobsList({
                   />
 
                   <View style={{ flex: 1, minWidth: 0, gap: 4 }}>
-                    <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                    <View
+                      style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}
+                    >
                       <Text
                         style={{
                           ...BrandType.heading,
@@ -140,7 +152,11 @@ export function InstructorOpenJobsList({
                         <DotStatusPill
                           backgroundColor={pillBackground}
                           color={dotColor}
-                          label={t(getApplicationStatusTranslationKey(job.applicationStatus!))}
+                          label={t(
+                            getApplicationStatusTranslationKey(
+                              job.applicationStatus!,
+                            ),
+                          )}
                         />
                       ) : null}
                     </View>
@@ -159,7 +175,10 @@ export function InstructorOpenJobsList({
 
                     {job.note ? (
                       <Text
-                        style={{ ...BrandType.caption, color: palette.textMuted as string }}
+                        style={{
+                          ...BrandType.caption,
+                          color: palette.textMuted as string,
+                        }}
                         numberOfLines={isWideWeb ? 1 : 2}
                       >
                         {job.note}
@@ -205,23 +224,26 @@ export function InstructorOpenJobsList({
                 >
                   {job.applicationStatus ? (
                     <DotStatusPill
-                      backgroundColor={pillBackground ?? (palette.surface as string)}
+                      backgroundColor={
+                        pillBackground ?? (palette.surface as string)
+                      }
                       color={dotColor ?? (palette.textMuted as string)}
-                      label={t(getApplicationStatusTranslationKey(job.applicationStatus))}
+                      label={t(
+                        getApplicationStatusTranslationKey(
+                          job.applicationStatus,
+                        ),
+                      )}
                     />
                   ) : (
-                    <KitButton
+                    <ActionButton
                       label={
                         applyingJobId === job.jobId
                           ? t("jobsTab.actions.applying")
                           : t("jobsTab.actions.apply")
                       }
                       onPress={() => onApply(job.jobId)}
-                      variant="primary"
-                      size="sm"
-                      fullWidth={false}
+                      palette={palette}
                       loading={applyingJobId === job.jobId}
-                      icon="arrow.right"
                     />
                   )}
                 </View>

--- a/src/components/jobs/studio-feed.tsx
+++ b/src/components/jobs/studio-feed.tsx
@@ -22,12 +22,16 @@ import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view"
 import { LoadingScreen } from "@/components/loading-screen";
 import { ThemedText } from "@/components/themed-text";
 import { EmptyState } from "@/components/ui/empty-state";
-import { KitButton, KitChip, KitSurface } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
+import { KitChip, KitSurface } from "@/components/ui/kit";
 import { NativeSearchField } from "@/components/ui/native-search-field";
 import { BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
 import { useAppInsets } from "@/hooks/use-app-insets";
 import { useBrand } from "@/hooks/use-brand";
-import { buildRoleTabRoute, ROLE_TAB_ROUTE_NAMES } from "@/navigation/role-routes";
+import {
+  buildRoleTabRoute,
+  ROLE_TAB_ROUTE_NAMES,
+} from "@/navigation/role-routes";
 
 type FeedSectionHeaderProps = {
   title: string;
@@ -40,7 +44,11 @@ type StudioFeedJobSummary = {
   status: string;
 };
 
-function FeedSectionHeader({ title, subtitle, palette }: FeedSectionHeaderProps) {
+function FeedSectionHeader({
+  title,
+  subtitle,
+  palette,
+}: FeedSectionHeaderProps) {
   return (
     <View style={styles.sectionHeader}>
       <ThemedText type="sectionTitle">{title}</ThemedText>
@@ -63,10 +71,14 @@ export function StudioFeed() {
   const locale = i18n.resolvedLanguage ?? "en";
   const zoneLanguage = locale.toLowerCase().startsWith("he") ? "he" : "en";
   const isWideWeb = Platform.OS === "web" && width >= 1180;
-  const mobileContentPaddingTop = Platform.OS === "android" ? safeTop + BrandSpacing.sm : 0;
+  const mobileContentPaddingTop =
+    Platform.OS === "android" ? safeTop + BrandSpacing.sm : 0;
   const signInRoute = "/sign-in" as const;
   const onboardingRoute = "/onboarding" as const;
-  const instructorJobsRoute = buildRoleTabRoute("instructor", ROLE_TAB_ROUTE_NAMES.jobs);
+  const instructorJobsRoute = buildRoleTabRoute(
+    "instructor",
+    ROLE_TAB_ROUTE_NAMES.jobs,
+  );
   const {
     createJobSheetRef,
     currentUser,
@@ -92,18 +104,22 @@ export function StudioFeed() {
     studioNotificationSettings,
   } = useStudioFeedController({ t });
   const screenStyle = useMemo(
-    () => StyleSheet.flatten([styles.screen, { backgroundColor: palette.appBg }]),
+    () =>
+      StyleSheet.flatten([styles.screen, { backgroundColor: palette.appBg }]),
     [palette.appBg],
   );
   const reviewCount =
     studioJobs?.reduce(
-      (total: number, job: StudioFeedJobSummary) => total + job.pendingApplicationsCount,
+      (total: number, job: StudioFeedJobSummary) =>
+        total + job.pendingApplicationsCount,
       0,
     ) ?? 0;
   const openCount =
-    studioJobs?.filter((job: StudioFeedJobSummary) => job.status === "open").length ?? 0;
+    studioJobs?.filter((job: StudioFeedJobSummary) => job.status === "open")
+      .length ?? 0;
   const filledCount =
-    studioJobs?.filter((job: StudioFeedJobSummary) => job.status === "filled").length ?? 0;
+    studioJobs?.filter((job: StudioFeedJobSummary) => job.status === "filled")
+      .length ?? 0;
   const reviewQueueJobs = filteredStudioJobsWithPayments.filter(
     (job: StudioFeedJobSummary) => job.pendingApplicationsCount > 0,
   );
@@ -124,9 +140,13 @@ export function StudioFeed() {
     { key: "completed", label: t("jobsTab.studioFeed.filterCompleted") },
   ] as const;
   const shouldSplitMobileBoard =
-    jobsStatusFilter === "all" && reviewQueueJobs.length > 0 && boardJobs.length > 0;
+    jobsStatusFilter === "all" &&
+    reviewQueueJobs.length > 0 &&
+    boardJobs.length > 0;
   const mobilePrimaryJobs =
-    jobsStatusFilter === "needs_review" ? reviewQueueJobs : filteredStudioJobsWithPayments;
+    jobsStatusFilter === "needs_review"
+      ? reviewQueueJobs
+      : filteredStudioJobsWithPayments;
 
   if (currentUser === undefined) {
     return <LoadingScreen label={t("jobsTab.loading")} />;
@@ -162,7 +182,13 @@ export function StudioFeed() {
           }}
           keyboardShouldPersistTaps="handled"
         >
-          <View style={{ flexDirection: "row", gap: BrandSpacing.xl, alignItems: "stretch" }}>
+          <View
+            style={{
+              flexDirection: "row",
+              gap: BrandSpacing.xl,
+              alignItems: "stretch",
+            }}
+          >
             <View
               style={{
                 flex: 1.2,
@@ -206,24 +232,28 @@ export function StudioFeed() {
                 {t("jobsTab.studioFeed.body")}
               </Text>
               <View style={{ flexDirection: "row", gap: 10 }}>
-                <KitButton
+                <ActionButton
                   label={t("jobsTab.form.title", "Post New Job")}
-                  icon="plus"
                   onPress={() => createJobSheetRef.current?.expand()}
-                  variant="secondary"
-                  fullWidth={false}
-                  style={{ backgroundColor: palette.onPrimary as string }}
+                  palette={palette}
+                  tone="secondary"
                 />
-                <KitButton
+                <ActionButton
                   label={
                     reviewCount > 0
-                      ? t("jobsTab.studioFeed.reviewAction", { count: reviewCount })
+                      ? t("jobsTab.studioFeed.reviewAction", {
+                          count: reviewCount,
+                        })
                       : t("jobsTab.studioFeed.queueClear")
                   }
                   onPress={() => setJobsStatusFilter("needs_review")}
-                  variant="secondary"
-                  fullWidth={false}
-                  style={{ backgroundColor: "rgba(255,255,255,0.16)" }}
+                  palette={{
+                    ...palette,
+                    surface: "rgba(255,255,255,0.16)",
+                    borderStrong: "rgba(255,255,255,0.24)",
+                    text: palette.onPrimary,
+                  }}
+                  tone="secondary"
                 />
               </View>
             </View>
@@ -316,7 +346,13 @@ export function StudioFeed() {
             />
           ) : null}
 
-          <View style={{ flexDirection: "row", gap: BrandSpacing.xl, alignItems: "flex-start" }}>
+          <View
+            style={{
+              flexDirection: "row",
+              gap: BrandSpacing.xl,
+              alignItems: "flex-start",
+            }}
+          >
             <View style={{ flex: 1.35, gap: BrandSpacing.xl, minWidth: 0 }}>
               {reviewQueueJobs.length > 0 ? (
                 <View
@@ -367,7 +403,9 @@ export function StudioFeed() {
                 <View style={{ paddingHorizontal: 18 }}>
                   <FeedSectionHeader
                     title={t("jobsTab.studioFeed.boardTitle")}
-                    subtitle={t("jobsTab.studioFeed.boardSubtitle", { count: boardJobs.length })}
+                    subtitle={t("jobsTab.studioFeed.boardSubtitle", {
+                      count: boardJobs.length,
+                    })}
                     palette={palette}
                   />
                 </View>
@@ -376,18 +414,41 @@ export function StudioFeed() {
                   <View style={[styles.emptyStateWrap, { minHeight: 320 }]}>
                     <ActivityIndicator
                       size="small"
-                      color={palette.primary as import("react-native").ColorValue}
+                      color={
+                        palette.primary as import("react-native").ColorValue
+                      }
                     />
-                    <ThemedText style={{ color: palette.textMuted, marginTop: BrandSpacing.xs }}>
+                    <ThemedText
+                      style={{
+                        color: palette.textMuted,
+                        marginTop: BrandSpacing.xs,
+                      }}
+                    >
                       {t("jobsTab.loading")}
                     </ThemedText>
                   </View>
                 ) : studioJobs.length === 0 ? (
-                  <View style={{ flex: 1, minHeight: 360, justifyContent: "center" }}>
-                    <EmptyState icon="bag" title={t("jobsTab.emptyStudio")} body="" />
+                  <View
+                    style={{
+                      flex: 1,
+                      minHeight: 360,
+                      justifyContent: "center",
+                    }}
+                  >
+                    <EmptyState
+                      icon="bag"
+                      title={t("jobsTab.emptyStudio")}
+                      body=""
+                    />
                   </View>
                 ) : filteredStudioJobs.length === 0 ? (
-                  <View style={{ flex: 1, minHeight: 260, justifyContent: "center" }}>
+                  <View
+                    style={{
+                      flex: 1,
+                      minHeight: 260,
+                      justifyContent: "center",
+                    }}
+                  >
                     <EmptyState
                       icon="magnifyingglass"
                       title={t("jobsTab.noJobsFound")}
@@ -411,7 +472,13 @@ export function StudioFeed() {
                     t={t}
                   />
                 ) : (
-                  <View style={{ flex: 1, minHeight: 240, justifyContent: "center" }}>
+                  <View
+                    style={{
+                      flex: 1,
+                      minHeight: 240,
+                      justifyContent: "center",
+                    }}
+                  >
                     <EmptyState
                       icon="checkmark.circle"
                       title={t("jobsTab.boardEmptyTitle")}
@@ -441,8 +508,12 @@ export function StudioFeed() {
                 <NativeSearchField
                   value={jobsSearchQuery}
                   onChangeText={setJobsSearchQuery}
-                  placeholder={t("jobsTab.searchPlaceholder", { defaultValue: "Search jobs" })}
-                  clearAccessibilityLabel={t("common.clear", { defaultValue: "Clear search" })}
+                  placeholder={t("jobsTab.searchPlaceholder", {
+                    defaultValue: "Search jobs",
+                  })}
+                  clearAccessibilityLabel={t("common.clear", {
+                    defaultValue: "Clear search",
+                  })}
                 />
                 <ScrollView
                   horizontal
@@ -455,7 +526,9 @@ export function StudioFeed() {
                       label={option.label}
                       selected={jobsStatusFilter === option.key}
                       onPress={() => {
-                        setJobsStatusFilter(option.key as StudioJobsStatusFilter);
+                        setJobsStatusFilter(
+                          option.key as StudioJobsStatusFilter,
+                        );
                       }}
                     />
                   ))}
@@ -479,13 +552,14 @@ export function StudioFeed() {
                     subtitle={t("jobsTab.studioPushDescription")}
                     palette={palette}
                   />
-                  <KitButton
+                  <ActionButton
                     label={
                       isEnablingStudioPush
                         ? t("jobsTab.actions.enablingPush")
                         : t("jobsTab.actions.enablePush")
                     }
-                    variant="secondary"
+                    palette={palette}
+                    tone="secondary"
                     onPress={() => {
                       void enableStudioPush();
                     }}
@@ -504,13 +578,24 @@ export function StudioFeed() {
                   gap: 8,
                 }}
               >
-                <Text style={{ ...BrandType.heading, fontSize: 24, color: palette.text as string }}>
+                <Text
+                  style={{
+                    ...BrandType.heading,
+                    fontSize: 24,
+                    color: palette.text as string,
+                  }}
+                >
                   Workflow
                 </Text>
-                <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
-                  Review stays detailed only while a decision is needed. The board compresses once a
-                  job is staffed or settled, so web reads like an operations desk instead of a long
-                  mobile feed.
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  Review stays detailed only while a decision is needed. The
+                  board compresses once a job is staffed or settled, so web
+                  reads like an operations desk instead of a long mobile feed.
                 </Text>
               </View>
             </View>
@@ -535,7 +620,10 @@ export function StudioFeed() {
       <TabScreenScrollView
         routeKey="studio/jobs/index"
         style={styles.screen}
-        contentContainerStyle={[styles.content, { paddingTop: mobileContentPaddingTop }]}
+        contentContainerStyle={[
+          styles.content,
+          { paddingTop: mobileContentPaddingTop },
+        ]}
         topInsetTone="sheet"
         keyboardShouldPersistTaps="handled"
       >
@@ -591,8 +679,9 @@ export function StudioFeed() {
                   {
                     label: "Open",
                     value: String(
-                      studioJobs?.filter((job: StudioFeedJobSummary) => job.status === "open")
-                        .length ?? 0,
+                      studioJobs?.filter(
+                        (job: StudioFeedJobSummary) => job.status === "open",
+                      ).length ?? 0,
                     ),
                     accent: palette.primary as string,
                   },
@@ -609,8 +698,9 @@ export function StudioFeed() {
                   {
                     label: "Filled",
                     value: String(
-                      studioJobs?.filter((job: StudioFeedJobSummary) => job.status === "filled")
-                        .length ?? 0,
+                      studioJobs?.filter(
+                        (job: StudioFeedJobSummary) => job.status === "filled",
+                      ).length ?? 0,
                     ),
                     accent: palette.success as string,
                   },
@@ -684,22 +774,23 @@ export function StudioFeed() {
                       color: palette.textMuted as string,
                     }}
                   >
-                    Create shifts, review applicants, and move payment work from one lane.
+                    Create shifts, review applicants, and move payment work from
+                    one lane.
                   </Text>
                 </View>
-                <KitButton
+                <ActionButton
                   label={t("jobsTab.form.title", "Post New Job")}
-                  icon="plus"
                   onPress={() => createJobSheetRef.current?.expand()}
-                  variant="primary"
-                  fullWidth={false}
+                  palette={palette}
                 />
               </View>
             </KitSurface>
 
             {studioNotificationSettings !== undefined &&
             !studioNotificationSettings?.hasExpoPushToken ? (
-              <View style={[styles.section, { borderBottomColor: "transparent" }]}>
+              <View
+                style={[styles.section, { borderBottomColor: "transparent" }]}
+              >
                 <FeedSectionHeader
                   title={t("jobsTab.notificationsTitle")}
                   subtitle={t("jobsTab.studioPushDescription")}
@@ -711,13 +802,14 @@ export function StudioFeed() {
                       {t("jobsTab.studioPushDescription")}
                     </ThemedText>
                   </View>
-                  <KitButton
+                  <ActionButton
                     label={
                       isEnablingStudioPush
                         ? t("jobsTab.actions.enablingPush")
                         : t("jobsTab.actions.enablePush")
                     }
-                    variant="secondary"
+                    palette={palette}
+                    tone="secondary"
                     onPress={() => {
                       void enableStudioPush();
                     }}
@@ -755,8 +847,12 @@ export function StudioFeed() {
                 <NativeSearchField
                   value={jobsSearchQuery}
                   onChangeText={setJobsSearchQuery}
-                  placeholder={t("jobsTab.searchPlaceholder", { defaultValue: "Search jobs" })}
-                  clearAccessibilityLabel={t("common.clear", { defaultValue: "Clear search" })}
+                  placeholder={t("jobsTab.searchPlaceholder", {
+                    defaultValue: "Search jobs",
+                  })}
+                  clearAccessibilityLabel={t("common.clear", {
+                    defaultValue: "Clear search",
+                  })}
                 />
                 <ScrollView
                   horizontal
@@ -771,7 +867,9 @@ export function StudioFeed() {
                         label={option.label}
                         selected={selected}
                         onPress={() => {
-                          setJobsStatusFilter(option.key as StudioJobsStatusFilter);
+                          setJobsStatusFilter(
+                            option.key as StudioJobsStatusFilter,
+                          );
                         }}
                       />
                     );
@@ -784,16 +882,29 @@ export function StudioFeed() {
                     size="small"
                     color={palette.primary as import("react-native").ColorValue}
                   />
-                  <ThemedText style={{ color: palette.textMuted, marginTop: BrandSpacing.xs }}>
+                  <ThemedText
+                    style={{
+                      color: palette.textMuted,
+                      marginTop: BrandSpacing.xs,
+                    }}
+                  >
                     {t("jobsTab.loading")}
                   </ThemedText>
                 </View>
               ) : studioJobs.length === 0 ? (
-                <View style={{ flex: 1, minHeight: 400, justifyContent: "center" }}>
-                  <EmptyState icon="bag" title={t("jobsTab.emptyStudio")} body="" />
+                <View
+                  style={{ flex: 1, minHeight: 400, justifyContent: "center" }}
+                >
+                  <EmptyState
+                    icon="bag"
+                    title={t("jobsTab.emptyStudio")}
+                    body=""
+                  />
                 </View>
               ) : filteredStudioJobs.length === 0 ? (
-                <View style={{ flex: 1, minHeight: 260, justifyContent: "center" }}>
+                <View
+                  style={{ flex: 1, minHeight: 260, justifyContent: "center" }}
+                >
                   <EmptyState
                     icon="magnifyingglass"
                     title={t("jobsTab.noJobsFound")}
@@ -830,7 +941,9 @@ export function StudioFeed() {
                   <View style={{ gap: BrandSpacing.xs }}>
                     <FeedSectionHeader
                       title={t("jobsTab.studioFeed.boardTitle")}
-                      subtitle={t("jobsTab.studioFeed.boardSubtitle", { count: boardJobs.length })}
+                      subtitle={t("jobsTab.studioFeed.boardSubtitle", {
+                        count: boardJobs.length,
+                      })}
                       palette={palette}
                     />
                     <StudioJobsList

--- a/src/components/jobs/studio/studio-jobs-list.tsx
+++ b/src/components/jobs/studio/studio-jobs-list.tsx
@@ -2,8 +2,14 @@ import type { TFunction } from "i18next";
 import { Text, View } from "react-native";
 import Animated, { FadeInUp } from "react-native-reanimated";
 import { DotStatusPill, MetricCell } from "@/components/home/home-shared";
-import { KitButton, KitSurface } from "@/components/ui/kit";
-import { type BrandPalette, BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
+import { ActionButton } from "@/components/ui/action-button";
+import { KitSurface } from "@/components/ui/kit";
+import {
+  type BrandPalette,
+  BrandRadius,
+  BrandSpacing,
+  BrandType,
+} from "@/constants/brand";
 import { getZoneLabel } from "@/constants/zones";
 import type { Id } from "@/convex/_generated/dataModel";
 import { toSportLabel } from "@/convex/constants";
@@ -54,7 +60,10 @@ type StudioJobsListProps = {
   palette: BrandPalette;
   reviewingApplicationId: Id<"jobApplications"> | null;
   payingJobId: Id<"jobs"> | null;
-  onReview: (applicationId: Id<"jobApplications">, status: "accepted" | "rejected") => void;
+  onReview: (
+    applicationId: Id<"jobApplications">,
+    status: "accepted" | "rejected",
+  ) => void;
   onStartPayment: (jobId: Id<"jobs">) => void;
   t: TFunction;
 };
@@ -79,14 +88,20 @@ const PAYOUT_STATUS_KEY: Record<PayoutStatus, string> = {
   needs_attention: "jobsTab.checkout.payoutStatus.needsAttention",
 };
 
-function jobStatusDot(status: StudioJob["status"], palette: BrandPalette): string {
+function jobStatusDot(
+  status: StudioJob["status"],
+  palette: BrandPalette,
+): string {
   const tone = getJobStatusTone(status);
   if (tone === "primary") return palette.primary as string;
   if (tone === "success") return palette.success as string;
   return palette.textMuted as string;
 }
 
-function paymentDotColor(status: PaymentStatus | undefined, palette: BrandPalette): string {
+function paymentDotColor(
+  status: PaymentStatus | undefined,
+  palette: BrandPalette,
+): string {
   if (!status) return palette.textMuted as string;
   const tone = getPaymentStatusTone(status);
   if (tone === "success") return palette.success as string;
@@ -95,7 +110,10 @@ function paymentDotColor(status: PaymentStatus | undefined, palette: BrandPalett
   return palette.primary as string;
 }
 
-function appStatusDot(status: StudioJobApplication["status"], palette: BrandPalette): string {
+function appStatusDot(
+  status: StudioJobApplication["status"],
+  palette: BrandPalette,
+): string {
   if (status === "accepted") return palette.success as string;
   if (status === "rejected") return palette.danger as string;
   if (status === "pending") return palette.warning as string;
@@ -109,7 +127,10 @@ type ApplicationRowProps = {
   palette: BrandPalette;
   reviewingApplicationId: Id<"jobApplications"> | null;
   canReview: boolean;
-  onReview: (applicationId: Id<"jobApplications">, status: "accepted" | "rejected") => void;
+  onReview: (
+    applicationId: Id<"jobApplications">,
+    status: "accepted" | "rejected",
+  ) => void;
   t: TFunction;
 };
 
@@ -143,7 +164,9 @@ function ApplicationRow({
           paddingVertical: 12,
         }}
       >
-        <View style={{ flex: isWideWeb ? 1.5 : undefined, minWidth: 0, gap: 3 }}>
+        <View
+          style={{ flex: isWideWeb ? 1.5 : undefined, minWidth: 0, gap: 3 }}
+        >
           <Text
             style={{
               ...BrandType.bodyStrong,
@@ -157,7 +180,10 @@ function ApplicationRow({
           </Text>
           {application.message ? (
             <Text
-              style={{ ...BrandType.caption, color: palette.textMuted as string }}
+              style={{
+                ...BrandType.caption,
+                color: palette.textMuted as string,
+              }}
               numberOfLines={isWideWeb ? 1 : 2}
             >
               {application.message}
@@ -192,20 +218,25 @@ function ApplicationRow({
               gap: BrandSpacing.sm,
             }}
           >
-            <KitButton
-              label={isReviewing ? t("jobsTab.actions.rejecting") : t("jobsTab.actions.reject")}
+            <ActionButton
+              label={
+                isReviewing
+                  ? t("jobsTab.actions.rejecting")
+                  : t("jobsTab.actions.reject")
+              }
               onPress={() => onReview(application.applicationId, "rejected")}
-              variant="secondary"
-              size="sm"
-              fullWidth={false}
+              palette={palette}
+              tone="secondary"
               disabled={isReviewing}
             />
-            <KitButton
-              label={isReviewing ? t("jobsTab.actions.accepting") : t("jobsTab.actions.accept")}
+            <ActionButton
+              label={
+                isReviewing
+                  ? t("jobsTab.actions.accepting")
+                  : t("jobsTab.actions.accept")
+              }
               onPress={() => onReview(application.applicationId, "accepted")}
-              variant="primary"
-              size="sm"
-              fullWidth={false}
+              palette={palette}
               loading={isReviewing}
             />
           </View>
@@ -244,9 +275,13 @@ export function StudioJobsList({
           ["filled", "completed"].includes(job.status) &&
           !(
             job.payment &&
-            ["created", "pending", "authorized", "captured", "refunded"].includes(
-              job.payment.status,
-            )
+            [
+              "created",
+              "pending",
+              "authorized",
+              "captured",
+              "refunded",
+            ].includes(job.payment.status)
           );
         const acceptedApplication = job.applications.find(
           (application) => application.status === "accepted",
@@ -262,7 +297,9 @@ export function StudioJobsList({
                   count: job.applicationsCount,
                   defaultValue: `${String(job.applicationsCount)} reviewed`,
                 })
-              : t("jobsTab.card.noApplicants", { defaultValue: "No applicants" });
+              : t("jobsTab.card.noApplicants", {
+                  defaultValue: "No applicants",
+                });
         const listTone =
           job.pendingApplicationsCount > 0
             ? (palette.primarySubtle as string)
@@ -296,8 +333,16 @@ export function StudioJobsList({
                     gap: isWideWeb ? 16 : 12,
                   }}
                 >
-                  <View style={{ flex: isWideWeb ? 1.6 : undefined, minWidth: 0, gap: 6 }}>
-                    <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                  <View
+                    style={{
+                      flex: isWideWeb ? 1.6 : undefined,
+                      minWidth: 0,
+                      gap: 6,
+                    }}
+                  >
+                    <View
+                      style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}
+                    >
                       <Text
                         style={{
                           ...BrandType.heading,
@@ -327,7 +372,10 @@ export function StudioJobsList({
                     </View>
 
                     <Text
-                      style={{ ...BrandType.caption, color: palette.textMuted as string }}
+                      style={{
+                        ...BrandType.caption,
+                        color: palette.textMuted as string,
+                      }}
                       numberOfLines={1}
                     >
                       {pendingLabel}
@@ -335,7 +383,10 @@ export function StudioJobsList({
 
                     {acceptedApplication ? (
                       <Text
-                        style={{ ...BrandType.caption, color: palette.textMuted as string }}
+                        style={{
+                          ...BrandType.caption,
+                          color: palette.textMuted as string,
+                        }}
                         numberOfLines={1}
                       >
                         {t("jobsTab.card.assignedInstructor", {
@@ -368,7 +419,9 @@ export function StudioJobsList({
                     <MetricCell
                       align={isWideWeb ? "flex-end" : "flex-start"}
                       icon="creditcard.fill"
-                      label={t("jobsTab.card.payLabel", { defaultValue: "Pay" })}
+                      label={t("jobsTab.card.payLabel", {
+                        defaultValue: "Pay",
+                      })}
                       value={t("jobsTab.card.pay", { value: job.pay })}
                       palette={palette}
                     />
@@ -404,7 +457,9 @@ export function StudioJobsList({
                           color: palette.textMuted as string,
                         }}
                       >
-                        {t("jobsTab.card.settlement", { defaultValue: "Settlement" })}
+                        {t("jobsTab.card.settlement", {
+                          defaultValue: "Settlement",
+                        })}
                       </Text>
                       <DotStatusPill
                         backgroundColor={palette.surfaceAlt as string}
@@ -412,7 +467,9 @@ export function StudioJobsList({
                         label={
                           job.payment
                             ? t(PAYMENT_STATUS_KEY[job.payment.status], {
-                                defaultValue: getPaymentStatusLabel(job.payment.status),
+                                defaultValue: getPaymentStatusLabel(
+                                  job.payment.status,
+                                ),
                               })
                             : t("jobsTab.checkout.notStarted")
                         }
@@ -421,27 +478,33 @@ export function StudioJobsList({
                         <DotStatusPill
                           backgroundColor={palette.surfaceAlt as string}
                           color={palette.text as string}
-                          label={t(PAYOUT_STATUS_KEY[job.payment.payoutStatus], {
-                            defaultValue: getPayoutStatusLabel(job.payment.payoutStatus),
-                          })}
+                          label={t(
+                            PAYOUT_STATUS_KEY[job.payment.payoutStatus],
+                            {
+                              defaultValue: getPayoutStatusLabel(
+                                job.payment.payoutStatus,
+                              ),
+                            },
+                          )}
                         />
                       ) : null}
                     </View>
 
                     {canPay ? (
-                      <KitButton
+                      <ActionButton
                         label={
                           payingJobId === job.jobId
                             ? t("jobsTab.checkout.starting")
-                            : job.payment && ["failed", "cancelled"].includes(job.payment.status)
+                            : job.payment &&
+                                ["failed", "cancelled"].includes(
+                                  job.payment.status,
+                                )
                               ? t("jobsTab.checkout.retryPayment")
                               : t("jobsTab.checkout.payNow")
                         }
                         onPress={() => onStartPayment(job.jobId)}
+                        palette={palette}
                         loading={payingJobId === job.jobId}
-                        variant="primary"
-                        size="sm"
-                        fullWidth={false}
                       />
                     ) : null}
                   </View>
@@ -464,7 +527,9 @@ export function StudioJobsList({
                           color: palette.textMuted as string,
                         }}
                       >
-                        {t("jobsTab.card.reviewQueue", { defaultValue: "Review queue" })}
+                        {t("jobsTab.card.reviewQueue", {
+                          defaultValue: "Review queue",
+                        })}
                       </Text>
                       <Text
                         style={{
@@ -488,7 +553,10 @@ export function StudioJobsList({
                         locale={locale}
                         palette={palette}
                         reviewingApplicationId={reviewingApplicationId}
-                        canReview={application.status === "pending" && job.status === "open"}
+                        canReview={
+                          application.status === "pending" &&
+                          job.status === "open"
+                        }
                         onReview={onReview}
                         t={t}
                       />
@@ -504,7 +572,12 @@ export function StudioJobsList({
                       paddingVertical: 12,
                     }}
                   >
-                    <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+                    <Text
+                      style={{
+                        ...BrandType.caption,
+                        color: palette.textMuted as string,
+                      }}
+                    >
                       {t("jobsTab.card.assignedTo", {
                         name: acceptedApplication.instructorName,
                         defaultValue: `Assigned to ${acceptedApplication.instructorName}`,
@@ -521,7 +594,12 @@ export function StudioJobsList({
                       paddingVertical: 12,
                     }}
                   >
-                    <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+                    <Text
+                      style={{
+                        ...BrandType.caption,
+                        color: palette.textMuted as string,
+                      }}
+                    >
                       {t("jobsTab.card.applicantsProcessed", {
                         count: job.applicationsCount,
                         defaultValue: `${String(job.applicationsCount)} applicants processed`,
@@ -538,9 +616,15 @@ export function StudioJobsList({
                       paddingVertical: 12,
                     }}
                   >
-                    <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+                    <Text
+                      style={{
+                        ...BrandType.caption,
+                        color: palette.textMuted as string,
+                      }}
+                    >
                       {t("jobsTab.card.liveOnBoard", {
-                        defaultValue: "Live on the board — new applicants arrive here.",
+                        defaultValue:
+                          "Live on the board — new applicants arrive here.",
                       })}
                     </Text>
                   </View>

--- a/src/components/ui/action-button.tsx
+++ b/src/components/ui/action-button.tsx
@@ -1,0 +1,70 @@
+import { ActivityIndicator, Pressable, Text } from "react-native";
+
+import type { BrandPalette } from "@/constants/brand";
+import { BrandRadius, BrandType } from "@/constants/brand";
+
+type ActionButtonTone = "primary" | "secondary";
+
+type ActionButtonProps = {
+  label: string;
+  onPress: () => void;
+  palette: BrandPalette;
+  tone?: ActionButtonTone;
+  disabled?: boolean;
+  loading?: boolean;
+  fullWidth?: boolean;
+};
+
+export function ActionButton({
+  label,
+  onPress,
+  palette,
+  tone = "primary",
+  disabled = false,
+  loading = false,
+  fullWidth = false,
+}: ActionButtonProps) {
+  const isDisabled = disabled || loading;
+  const backgroundColor =
+    tone === "primary" ? (palette.primary as string) : (palette.surface as string);
+  const borderColor = tone === "primary" ? "transparent" : (palette.borderStrong as string);
+  const textColor = tone === "primary" ? (palette.onPrimary as string) : (palette.text as string);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
+      disabled={isDisabled}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        minHeight: 42,
+        minWidth: 96,
+        alignSelf: fullWidth ? "stretch" : "flex-start",
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 14,
+        paddingVertical: 10,
+        borderWidth: tone === "primary" ? 0 : 1,
+        borderRadius: BrandRadius.button,
+        borderCurve: "continuous",
+        borderColor,
+        backgroundColor,
+        opacity: isDisabled ? 0.6 : pressed ? 0.92 : 1,
+      })}
+    >
+      {loading ? (
+        <ActivityIndicator color={textColor} />
+      ) : (
+        <Text
+          style={{
+            ...BrandType.bodyMedium,
+            color: textColor,
+            includeFontPadding: false,
+          }}
+        >
+          {label}
+        </Text>
+      )}
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## What changed
- remove chart-first home composition from instructor and studio home
- collapse home to a single lead action card plus the live work section
- remove kit button and kit pressable usage from the touched home surfaces
- replace main instructor/studio job card actions with a simple non-kit action button
- move studio feed top-level actions off KitButton

## Why
Home was spending too much of the first screenful on summary theater and the main feed actions were still tied to the kit controls you explicitly called out as problematic. This slice makes the product more action-first without trying to redesign every screen at once.

## Verification
- bun run typecheck
