### PR TITLE
UI Cut 03: flatten jobs feeds into list-first boards

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -482,6 +482,26 @@ Replace with consequence and momentum:
 - simplify map control layering
 - replace calendar gesture cleverness with clearer date navigation
 
+## Execution Log
+
+### Slice 01
+
+- removed the fake dual-style theme split
+- deleted dead kit pieces that only existed to support that fiction
+- reduced theme logic to one honest path
+
+### Slice 02
+
+- stripped home back toward action-first content
+- removed chart-first and stat-heavy lead sections
+- replaced feed actions that depended on `KitButton` and `KitPressable`
+
+### Slice 03
+
+- rebuilt jobs feeds into one native-first page shape per role
+- deleted wide-web hero cards, metric rails, workflow panels, and duplicate mobile ops blocks
+- kept the jobs surface focused on filters, queue state, and the actual list
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/components/jobs/instructor-feed.tsx
+++ b/src/components/jobs/instructor-feed.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from "convex/react";
 import { Redirect } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Platform, StyleSheet, Text, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
 import { InstructorOpenJobsList } from "@/components/jobs/instructor/instructor-open-jobs-list";
 import { NoticeBanner } from "@/components/jobs/notice-banner";
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
@@ -11,15 +11,17 @@ import { ThemedText } from "@/components/themed-text";
 import { EmptyState } from "@/components/ui/empty-state";
 import { KitChip, KitSurface } from "@/components/ui/kit";
 import { NativeSearchField } from "@/components/ui/native-search-field";
-import { BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
+import { BrandSpacing } from "@/constants/brand";
 import { getZoneLabel } from "@/constants/zones";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { toSportLabel } from "@/convex/constants";
 import { useAppInsets } from "@/hooks/use-app-insets";
 import { useBrand } from "@/hooks/use-brand";
-import { useLayoutBreakpoint } from "@/hooks/use-layout-breakpoint";
-import { buildRoleTabRoute, ROLE_TAB_ROUTE_NAMES } from "@/navigation/role-routes";
+import {
+  buildRoleTabRoute,
+  ROLE_TAB_ROUTE_NAMES,
+} from "@/navigation/role-routes";
 
 function SectionHeader({
   title,
@@ -48,17 +50,24 @@ export function InstructorFeed() {
   const { safeTop } = useAppInsets();
   const locale = i18n.resolvedLanguage ?? "en";
   const zoneLanguage = locale.toLowerCase().startsWith("he") ? "he" : "en";
-  const { isDesktopWeb: isWideWeb } = useLayoutBreakpoint();
-  const mobileContentPaddingTop = Platform.OS === "android" ? safeTop + BrandSpacing.sm : 0;
+  const mobileContentPaddingTop =
+    Platform.OS === "android" ? safeTop + BrandSpacing.sm : 0;
 
   const [jobsSearchQuery, setJobsSearchQuery] = useState("");
-  const [jobsWindowFilter, setJobsWindowFilter] = useState<"all" | "24h" | "72h">("all");
+  const [jobsWindowFilter, setJobsWindowFilter] = useState<
+    "all" | "24h" | "72h"
+  >("all");
   const [applyingJobId, setApplyingJobId] = useState<Id<"jobs"> | null>(null);
-  const [applyErrorMessage, setApplyErrorMessage] = useState<string | null>(null);
+  const [applyErrorMessage, setApplyErrorMessage] = useState<string | null>(
+    null,
+  );
 
   const currentUser = useQuery(api.users.getCurrentUser);
   const applyToJob = useMutation(api.jobs.applyToJob);
-  const studioHomeRoute = buildRoleTabRoute("studio", ROLE_TAB_ROUTE_NAMES.home);
+  const studioHomeRoute = buildRoleTabRoute(
+    "studio",
+    ROLE_TAB_ROUTE_NAMES.home,
+  );
 
   const now = Date.now();
   const queryMinuteBucket = Math.floor(now / (60 * 1000));
@@ -95,13 +104,21 @@ export function InstructorFeed() {
   type AvailableJob = NonNullable<typeof availableJobs>[number];
 
   const jobs = (availableJobs ?? []) as AvailableJob[];
-  const hotNowCount = jobs.filter((job) => job.startTime <= now + 24 * 60 * 60 * 1000).length;
-  const pendingCount = jobs.filter((job) => job.applicationStatus === "pending").length;
-  const acceptedCount = jobs.filter((job) => job.applicationStatus === "accepted").length;
+  const hotNowCount = jobs.filter(
+    (job) => job.startTime <= now + 24 * 60 * 60 * 1000,
+  ).length;
+  const pendingCount = jobs.filter(
+    (job) => job.applicationStatus === "pending",
+  ).length;
+  const acceptedCount = jobs.filter(
+    (job) => job.applicationStatus === "accepted",
+  ).length;
 
   const filteredAvailableJobs = jobs.filter((job) => {
-    if (jobsWindowFilter === "24h" && job.startTime > now + 24 * 60 * 60 * 1000) return false;
-    if (jobsWindowFilter === "72h" && job.startTime > now + 72 * 60 * 60 * 1000) return false;
+    if (jobsWindowFilter === "24h" && job.startTime > now + 24 * 60 * 60 * 1000)
+      return false;
+    if (jobsWindowFilter === "72h" && job.startTime > now + 72 * 60 * 60 * 1000)
+      return false;
 
     const search = jobsSearchQuery.trim().toLowerCase();
     if (!search) return true;
@@ -131,392 +148,95 @@ export function InstructorFeed() {
     { key: "72h", label: t("jobsTab.instructorFeed.filterThisWeek") },
   ] as const;
 
-  if (isWideWeb) {
-    return (
-      <View style={[styles.screen, { backgroundColor: palette.appBg }]}>
-        <TabScreenScrollView
-          routeKey="instructor/jobs/index"
-          style={styles.screen}
-          contentContainerStyle={{
-            paddingHorizontal: BrandSpacing.xl,
-            paddingTop: BrandSpacing.xl,
-            paddingBottom: BrandSpacing.xxl,
-            gap: BrandSpacing.xl,
-          }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <View style={{ flexDirection: "row", gap: BrandSpacing.xl, alignItems: "stretch" }}>
-            <View
-              style={{
-                flex: 1.2,
-                borderRadius: 34,
-                borderCurve: "continuous",
-                backgroundColor: palette.primary as string,
-                paddingHorizontal: 22,
-                paddingVertical: 22,
-                gap: 12,
-              }}
-            >
-              <Text
-                style={{
-                  ...BrandType.micro,
-                  color: palette.onPrimary as string,
-                  opacity: 0.8,
-                  letterSpacing: 0.2,
-                }}
-              >
-                {t("jobsTab.instructorFeed.eyebrow")}
-              </Text>
-              <Text
-                style={{
-                  fontFamily: "BarlowCondensed_800ExtraBold",
-                  fontSize: 42,
-                  lineHeight: 40,
-                  letterSpacing: -1,
-                  color: palette.onPrimary as string,
-                }}
-              >
-                {t("jobsTab.instructorFeed.title")}
-              </Text>
-              <Text
-                style={{
-                  ...BrandType.body,
-                  color: palette.onPrimary as string,
-                  opacity: 0.9,
-                  maxWidth: 620,
-                }}
-              >
-                {t("jobsTab.instructorFeed.body")}
-              </Text>
-              <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
-                {[
-                  t("jobsTab.instructorFeed.matchesCount", { count: filteredAvailableJobs.length }),
-                  hotNowCount > 0
-                    ? t("jobsTab.instructorFeed.hotNow", { count: hotNowCount })
-                    : t("jobsTab.instructorFeed.freshBoard"),
-                ].map((label) => (
-                  <View
-                    key={label}
-                    style={{
-                      borderRadius: 999,
-                      backgroundColor: "rgba(255,255,255,0.16)",
-                      paddingHorizontal: 12,
-                      paddingVertical: 8,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        ...BrandType.micro,
-                        color: palette.onPrimary as string,
-                        letterSpacing: 0.2,
-                      }}
-                    >
-                      {label}
-                    </Text>
-                  </View>
-                ))}
-              </View>
-            </View>
-
-            <View
-              style={{
-                width: 340,
-                borderRadius: 34,
-                borderCurve: "continuous",
-                backgroundColor: palette.surfaceAlt as string,
-                paddingHorizontal: 18,
-                paddingVertical: 18,
-                gap: 14,
-              }}
-            >
-              {[
-                {
-                  label: t("jobsTab.instructorFeed.metricHotNow"),
-                  value: hotNowCount,
-                  accent: palette.primary as string,
-                },
-                {
-                  label: t("jobsTab.instructorFeed.metricPending"),
-                  value: pendingCount,
-                  accent: palette.warning as string,
-                },
-                {
-                  label: t("jobsTab.instructorFeed.metricAccepted"),
-                  value: acceptedCount,
-                  accent: palette.success as string,
-                },
-              ].map((metric) => (
-                <View
-                  key={metric.label}
-                  style={{
-                    borderRadius: 24,
-                    borderCurve: "continuous",
-                    backgroundColor: palette.surface as string,
-                    paddingHorizontal: 14,
-                    paddingVertical: 14,
-                    gap: 2,
-                  }}
-                >
-                  <Text
-                    style={{
-                      ...BrandType.micro,
-                      color: palette.textMuted as string,
-                      letterSpacing: 0.2,
-                    }}
-                  >
-                    {metric.label}
-                  </Text>
-                  <Text
-                    style={{
-                      fontFamily: "BarlowCondensed_800ExtraBold",
-                      fontSize: 30,
-                      lineHeight: 28,
-                      color: metric.accent,
-                      fontVariant: ["tabular-nums"],
-                    }}
-                  >
-                    {String(metric.value)}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          </View>
-
-          {applyErrorMessage ? (
-            <NoticeBanner
-              tone="error"
-              message={applyErrorMessage}
-              onDismiss={() => setApplyErrorMessage(null)}
-              borderColor="transparent"
-              backgroundColor={palette.dangerSubtle}
-              textColor={palette.danger}
-              iconColor={palette.danger}
-            />
-          ) : null}
-
-          <View style={{ flexDirection: "row", gap: BrandSpacing.xl, alignItems: "flex-start" }}>
-            <View
-              style={{
-                flex: 1.4,
-                borderRadius: 32,
-                borderCurve: "continuous",
-                backgroundColor: palette.surface as string,
-                paddingVertical: 18,
-                gap: 12,
-              }}
-            >
-              <View style={{ paddingHorizontal: 18 }}>
-                <SectionHeader
-                  title={t("jobsTab.instructorFeed.openingsTitle")}
-                  subtitle={t("jobsTab.instructorFeed.openingsFiltered", {
-                    count: filteredAvailableJobs.length,
-                  })}
-                  palette={palette}
-                />
-              </View>
-
-              {jobs.length === 0 ? (
-                <View style={{ minHeight: 360, justifyContent: "center" }}>
-                  <EmptyState icon="briefcase" title={t("jobsTab.emptyInstructor")} body="" />
-                </View>
-              ) : filteredAvailableJobs.length === 0 ? (
-                <View style={{ minHeight: 320, justifyContent: "center" }}>
-                  <EmptyState
-                    icon="magnifyingglass"
-                    title={t("jobsTab.noJobsFound")}
-                    body={t("jobsTab.tryDifferentSearchOrTimeFilter")}
-                  />
-                </View>
-              ) : (
-                <InstructorOpenJobsList
-                  jobs={filteredAvailableJobs}
-                  locale={locale}
-                  zoneLanguage={zoneLanguage}
-                  palette={palette}
-                  applyingJobId={applyingJobId}
-                  onApply={(jobId) => {
-                    void onApply(jobId);
-                  }}
-                  t={t}
-                />
-              )}
-            </View>
-
-            <View style={{ width: 320, gap: 16 }}>
-              <View
-                style={{
-                  borderRadius: 30,
-                  borderCurve: "continuous",
-                  backgroundColor: palette.surface as string,
-                  paddingHorizontal: 18,
-                  paddingVertical: 18,
-                  gap: 12,
-                }}
-              >
-                <SectionHeader
-                  title={t("jobsTab.instructorFeed.filterDeskTitle")}
-                  subtitle={t("jobsTab.instructorFeed.filterDeskSubtitle")}
-                  palette={palette}
-                />
-                <NativeSearchField
-                  value={jobsSearchQuery}
-                  onChangeText={setJobsSearchQuery}
-                  placeholder={t("jobsTab.searchPlaceholder")}
-                  clearAccessibilityLabel={t("common.clear", { defaultValue: "Clear search" })}
-                />
-                <View style={styles.segmentRow}>
-                  {filterOptions.map((option) => (
-                    <KitChip
-                      key={option.key}
-                      label={option.label}
-                      selected={jobsWindowFilter === option.key}
-                      onPress={() => setJobsWindowFilter(option.key)}
-                    />
-                  ))}
-                </View>
-              </View>
-
-              <View
-                style={{
-                  borderRadius: 30,
-                  borderCurve: "continuous",
-                  backgroundColor: palette.surfaceAlt as string,
-                  paddingHorizontal: 18,
-                  paddingVertical: 18,
-                  gap: 8,
-                }}
-              >
-                <Text style={{ ...BrandType.heading, fontSize: 24, color: palette.text as string }}>
-                  {t("jobsTab.instructorFeed.pipelineTitle")}
-                </Text>
-                <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
-                  {t("jobsTab.instructorFeed.pipelineSubtitle")}
-                </Text>
-              </View>
-            </View>
-          </View>
-        </TabScreenScrollView>
-      </View>
-    );
-  }
-
   return (
     <View style={[styles.screen, { backgroundColor: palette.appBg }]}>
       <TabScreenScrollView
         routeKey="instructor/jobs/index"
         style={styles.screen}
-        contentContainerStyle={[styles.content, { paddingTop: mobileContentPaddingTop }]}
+        contentContainerStyle={[
+          styles.content,
+          {
+            paddingTop: mobileContentPaddingTop,
+            paddingHorizontal: BrandSpacing.lg,
+          },
+        ]}
         topInsetTone="sheet"
         keyboardShouldPersistTaps="handled"
       >
-        <View style={{ flex: 1, gap: BrandSpacing.md }}>
+        <View style={{ flex: 1, gap: BrandSpacing.lg }}>
+          <View style={{ gap: BrandSpacing.sm }}>
+            <SectionHeader
+              title={t("jobsTab.instructorFeed.title")}
+              subtitle={t("jobsTab.instructorFeed.openingsFiltered", {
+                count: filteredAvailableJobs.length,
+              })}
+              palette={palette}
+            />
+            {applyErrorMessage ? (
+              <NoticeBanner
+                tone="error"
+                message={applyErrorMessage}
+                onDismiss={() => setApplyErrorMessage(null)}
+                borderColor="transparent"
+                backgroundColor={palette.dangerSubtle}
+                textColor={palette.danger}
+                iconColor={palette.danger}
+              />
+            ) : null}
+          </View>
+
           <KitSurface
             tone="sheet"
             padding={BrandSpacing.lg}
             gap={BrandSpacing.md}
-            style={{
-              marginHorizontal: BrandSpacing.lg,
-            }}
           >
-            <SectionHeader
-              title={t("jobsTab.instructorFeed.mobileTitle")}
-              subtitle={t("jobsTab.instructorFeed.mobileSubtitle")}
-              palette={palette}
-            />
-            <View
-              style={{
-                flexDirection: "row",
-                gap: 10,
-              }}
+            <ThemedText
+              type="meta"
+              style={{ color: palette.textMuted as string }}
             >
               {[
-                {
-                  label: t("jobsTab.instructorFeed.metricHotNow"),
-                  value: String(hotNowCount),
-                  accent: palette.primary as string,
-                },
-                { label: t("jobsTab.instructorFeed.metricPending"), value: String(pendingCount) },
-                {
-                  label: t("jobsTab.instructorFeed.metricAccepted"),
-                  value: String(acceptedCount),
-                  accent: palette.success as string,
-                },
-              ].map((item) => (
-                <View
-                  key={item.label}
-                  style={{
-                    flex: 1,
-                    gap: 4,
-                    borderRadius: BrandRadius.card,
-                    borderCurve: "continuous",
-                    backgroundColor: palette.surface as string,
-                    paddingHorizontal: BrandSpacing.md,
-                    paddingVertical: BrandSpacing.md,
-                  }}
-                >
-                  <Text
-                    style={{
-                      ...BrandType.caption,
-                      color: palette.textMuted as string,
-                    }}
-                  >
-                    {item.label}
-                  </Text>
-                  <Text
-                    style={{
-                      ...BrandType.title,
-                      color: item.accent ?? (palette.text as string),
-                      fontVariant: ["tabular-nums"],
-                    }}
-                  >
-                    {item.value}
-                  </Text>
-                </View>
-              ))}
-            </View>
-
-            <View
-              style={{
-                gap: BrandSpacing.sm,
-                borderRadius: BrandRadius.card,
-                borderCurve: "continuous",
-                backgroundColor: palette.surface as string,
-                padding: 14,
-              }}
-            >
-              {applyErrorMessage ? (
-                <NoticeBanner
-                  tone="error"
-                  message={applyErrorMessage}
-                  onDismiss={() => setApplyErrorMessage(null)}
-                  borderColor="transparent"
-                  backgroundColor={palette.dangerSubtle}
-                  textColor={palette.danger}
-                  iconColor={palette.danger}
+                t("jobsTab.instructorFeed.matchesCount", {
+                  count: filteredAvailableJobs.length,
+                }),
+                hotNowCount > 0
+                  ? t("jobsTab.instructorFeed.hotNow", { count: hotNowCount })
+                  : t("jobsTab.instructorFeed.freshBoard"),
+                pendingCount > 0
+                  ? t("jobsTab.instructorFeed.metricPending", {
+                      defaultValue: "Pending",
+                    }) + `: ${String(pendingCount)}`
+                  : t("jobsTab.instructorFeed.metricAccepted", {
+                      defaultValue: "Accepted",
+                    }) + `: ${String(acceptedCount)}`,
+              ].join("  •  ")}
+            </ThemedText>
+            <NativeSearchField
+              value={jobsSearchQuery}
+              onChangeText={setJobsSearchQuery}
+              placeholder={t("jobsTab.searchPlaceholder")}
+              clearAccessibilityLabel={t("common.clear", {
+                defaultValue: "Clear search",
+              })}
+            />
+            <View style={styles.segmentRow}>
+              {filterOptions.map((option) => (
+                <KitChip
+                  key={option.key}
+                  label={option.label}
+                  selected={jobsWindowFilter === option.key}
+                  onPress={() => setJobsWindowFilter(option.key)}
                 />
-              ) : null}
-              <NativeSearchField
-                value={jobsSearchQuery}
-                onChangeText={setJobsSearchQuery}
-                placeholder={t("jobsTab.searchPlaceholder")}
-                clearAccessibilityLabel={t("common.clear", { defaultValue: "Clear search" })}
-              />
-              <View style={styles.segmentRow}>
-                {filterOptions.map((option) => (
-                  <KitChip
-                    key={option.key}
-                    label={option.label}
-                    selected={jobsWindowFilter === option.key}
-                    onPress={() => setJobsWindowFilter(option.key)}
-                  />
-                ))}
-              </View>
+              ))}
             </View>
           </KitSurface>
 
           {jobs.length === 0 ? (
             <View style={{ minHeight: 260, justifyContent: "center" }}>
-              <EmptyState icon="briefcase" title={t("jobsTab.emptyInstructor")} body="" />
+              <EmptyState
+                icon="briefcase"
+                title={t("jobsTab.emptyInstructor")}
+                body=""
+              />
             </View>
           ) : filteredAvailableJobs.length === 0 ? (
             <View
@@ -559,7 +279,7 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingTop: BrandSpacing.lg,
     paddingBottom: BrandSpacing.xl,
-    gap: BrandSpacing.md,
+    gap: BrandSpacing.lg,
   },
   segmentRow: {
     flexDirection: "row",

--- a/src/components/jobs/studio-feed.tsx
+++ b/src/components/jobs/studio-feed.tsx
@@ -1,14 +1,11 @@
 import { useIsFocused } from "@react-navigation/native";
 import { Redirect } from "expo-router";
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
   Platform,
   ScrollView,
   StyleSheet,
-  Text,
-  useWindowDimensions,
   View,
 } from "react-native";
 import { NoticeBanner } from "@/components/jobs/notice-banner";
@@ -21,11 +18,11 @@ import {
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
 import { ThemedText } from "@/components/themed-text";
-import { EmptyState } from "@/components/ui/empty-state";
 import { ActionButton } from "@/components/ui/action-button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { KitChip, KitSurface } from "@/components/ui/kit";
 import { NativeSearchField } from "@/components/ui/native-search-field";
-import { BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
+import { BrandSpacing } from "@/constants/brand";
 import { useAppInsets } from "@/hooks/use-app-insets";
 import { useBrand } from "@/hooks/use-brand";
 import {
@@ -64,13 +61,10 @@ function FeedSectionHeader({
 export function StudioFeed() {
   const { t, i18n } = useTranslation();
   const isFocused = useIsFocused();
-  const { width } = useWindowDimensions();
-
   const palette = useBrand();
   const { safeTop } = useAppInsets();
   const locale = i18n.resolvedLanguage ?? "en";
   const zoneLanguage = locale.toLowerCase().startsWith("he") ? "he" : "en";
-  const isWideWeb = Platform.OS === "web" && width >= 1180;
   const mobileContentPaddingTop =
     Platform.OS === "android" ? safeTop + BrandSpacing.sm : 0;
   const signInRoute = "/sign-in" as const;
@@ -103,11 +97,6 @@ export function StudioFeed() {
     studioJobs,
     studioNotificationSettings,
   } = useStudioFeedController({ t });
-  const screenStyle = useMemo(
-    () =>
-      StyleSheet.flatten([styles.screen, { backgroundColor: palette.appBg }]),
-    [palette.appBg],
-  );
   const reviewCount =
     studioJobs?.reduce(
       (total: number, job: StudioFeedJobSummary) =>
@@ -139,14 +128,29 @@ export function StudioFeed() {
     { key: "filled", label: t("jobsTab.studioFeed.filterFilled") },
     { key: "completed", label: t("jobsTab.studioFeed.filterCompleted") },
   ] as const;
-  const shouldSplitMobileBoard =
+  const shouldSplitBoard =
     jobsStatusFilter === "all" &&
     reviewQueueJobs.length > 0 &&
     boardJobs.length > 0;
-  const mobilePrimaryJobs =
+  const primaryJobs =
     jobsStatusFilter === "needs_review"
       ? reviewQueueJobs
       : filteredStudioJobsWithPayments;
+  const primarySectionShowsReviewQueue =
+    jobsStatusFilter === "needs_review" ||
+    (jobsStatusFilter === "all" &&
+      reviewQueueJobs.length > 0 &&
+      boardJobs.length === 0);
+  const primarySectionTitle = primarySectionShowsReviewQueue
+    ? t("jobsTab.studioFeed.needsReviewTitle")
+    : t("jobsTab.studioFeed.boardTitle");
+  const primarySectionSubtitle = primarySectionShowsReviewQueue
+    ? t("jobsTab.studioFeed.mobileDecisionWaiting", {
+        count: primaryJobs.length,
+      })
+    : t("jobsTab.studioFeed.boardSubtitle", {
+        count: primaryJobs.length,
+      });
 
   if (currentUser === undefined) {
     return <LoadingScreen label={t("jobsTab.loading")} />;
@@ -168,470 +172,30 @@ export function StudioFeed() {
     return <Redirect href={onboardingRoute} />;
   }
 
-  if (isWideWeb) {
-    return (
-      <View style={screenStyle}>
-        <TabScreenScrollView
-          routeKey="studio/jobs/index"
-          style={styles.screen}
-          contentContainerStyle={{
-            paddingHorizontal: BrandSpacing.xl,
-            paddingTop: BrandSpacing.xl,
-            paddingBottom: BrandSpacing.xxl,
-            gap: BrandSpacing.xl,
-          }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <View
-            style={{
-              flexDirection: "row",
-              gap: BrandSpacing.xl,
-              alignItems: "stretch",
-            }}
-          >
-            <View
-              style={{
-                flex: 1.2,
-                borderRadius: 34,
-                borderCurve: "continuous",
-                backgroundColor: palette.primary as string,
-                paddingHorizontal: 22,
-                paddingVertical: 22,
-                gap: 12,
-              }}
-            >
-              <Text
-                style={{
-                  ...BrandType.micro,
-                  color: palette.onPrimary as string,
-                  opacity: 0.8,
-                  letterSpacing: 0.2,
-                }}
-              >
-                {t("jobsTab.studioFeed.eyebrow")}
-              </Text>
-              <Text
-                style={{
-                  fontFamily: "BarlowCondensed_800ExtraBold",
-                  fontSize: 42,
-                  lineHeight: 40,
-                  letterSpacing: -1,
-                  color: palette.onPrimary as string,
-                }}
-              >
-                {t("jobsTab.studioFeed.title")}
-              </Text>
-              <Text
-                style={{
-                  ...BrandType.body,
-                  color: palette.onPrimary as string,
-                  opacity: 0.9,
-                  maxWidth: 620,
-                }}
-              >
-                {t("jobsTab.studioFeed.body")}
-              </Text>
-              <View style={{ flexDirection: "row", gap: 10 }}>
-                <ActionButton
-                  label={t("jobsTab.form.title", "Post New Job")}
-                  onPress={() => createJobSheetRef.current?.expand()}
-                  palette={palette}
-                  tone="secondary"
-                />
-                <ActionButton
-                  label={
-                    reviewCount > 0
-                      ? t("jobsTab.studioFeed.reviewAction", {
-                          count: reviewCount,
-                        })
-                      : t("jobsTab.studioFeed.queueClear")
-                  }
-                  onPress={() => setJobsStatusFilter("needs_review")}
-                  palette={{
-                    ...palette,
-                    surface: "rgba(255,255,255,0.16)",
-                    borderStrong: "rgba(255,255,255,0.24)",
-                    text: palette.onPrimary,
-                  }}
-                  tone="secondary"
-                />
-              </View>
-            </View>
-
-            <View
-              style={{
-                width: 340,
-                borderRadius: 34,
-                borderCurve: "continuous",
-                backgroundColor: palette.surfaceAlt as string,
-                paddingHorizontal: 18,
-                paddingVertical: 18,
-                gap: 14,
-              }}
-            >
-              {[
-                {
-                  label: t("jobsTab.studioFeed.metricReview"),
-                  value: reviewCount,
-                  accent: palette.primary as string,
-                },
-                {
-                  label: t("jobsTab.studioFeed.metricOpen"),
-                  value: openCount,
-                  accent: palette.text as string,
-                },
-                {
-                  label: t("jobsTab.studioFeed.metricFilled"),
-                  value: filledCount,
-                  accent: palette.success as string,
-                },
-              ].map((metric) => (
-                <View
-                  key={metric.label}
-                  style={{
-                    borderRadius: 24,
-                    borderCurve: "continuous",
-                    backgroundColor: palette.surface as string,
-                    paddingHorizontal: 14,
-                    paddingVertical: 14,
-                    gap: 2,
-                  }}
-                >
-                  <Text
-                    style={{
-                      ...BrandType.micro,
-                      color: palette.textMuted as string,
-                      letterSpacing: 0.2,
-                    }}
-                  >
-                    {metric.label}
-                  </Text>
-                  <Text
-                    style={{
-                      fontFamily: "BarlowCondensed_800ExtraBold",
-                      fontSize: 30,
-                      lineHeight: 28,
-                      color: metric.accent,
-                      fontVariant: ["tabular-nums"],
-                    }}
-                  >
-                    {String(metric.value)}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          </View>
-
-          {errorMessage ? (
-            <NoticeBanner
-              tone="error"
-              message={errorMessage}
-              onDismiss={() => setErrorMessage(null)}
-              borderColor={palette.borderStrong}
-              backgroundColor={palette.surface}
-              textColor={palette.danger}
-              iconColor={palette.danger}
-            />
-          ) : null}
-
-          {statusMessage ? (
-            <NoticeBanner
-              tone="success"
-              message={statusMessage}
-              onDismiss={() => setStatusMessage(null)}
-              borderColor={palette.borderStrong}
-              backgroundColor={palette.surface}
-              textColor={palette.text}
-              iconColor={palette.success as import("react-native").ColorValue}
-            />
-          ) : null}
-
-          <View
-            style={{
-              flexDirection: "row",
-              gap: BrandSpacing.xl,
-              alignItems: "flex-start",
-            }}
-          >
-            <View style={{ flex: 1.35, gap: BrandSpacing.xl, minWidth: 0 }}>
-              {reviewQueueJobs.length > 0 ? (
-                <View
-                  style={{
-                    borderRadius: 32,
-                    borderCurve: "continuous",
-                    backgroundColor: palette.surface as string,
-                    paddingVertical: 18,
-                    gap: 12,
-                  }}
-                >
-                  <View style={{ paddingHorizontal: 18 }}>
-                    <FeedSectionHeader
-                      title={t("jobsTab.studioFeed.needsReviewTitle")}
-                      subtitle={t("jobsTab.studioFeed.needsReviewSubtitle", {
-                        count: reviewQueueJobs.length,
-                      })}
-                      palette={palette}
-                    />
-                  </View>
-                  <StudioJobsList
-                    jobs={reviewQueueJobs}
-                    locale={locale}
-                    zoneLanguage={zoneLanguage}
-                    palette={palette}
-                    reviewingApplicationId={isReviewingApplicationId}
-                    payingJobId={isStartingCheckoutForJobId}
-                    onReview={(applicationId, status) => {
-                      void reviewStudioApplication(applicationId, status);
-                    }}
-                    onStartPayment={(jobId) => {
-                      void startStudioCheckout(jobId);
-                    }}
-                    t={t}
-                  />
-                </View>
-              ) : null}
-
-              <View
-                style={{
-                  borderRadius: 32,
-                  borderCurve: "continuous",
-                  backgroundColor: palette.surface as string,
-                  paddingVertical: 18,
-                  gap: 12,
-                }}
-              >
-                <View style={{ paddingHorizontal: 18 }}>
-                  <FeedSectionHeader
-                    title={t("jobsTab.studioFeed.boardTitle")}
-                    subtitle={t("jobsTab.studioFeed.boardSubtitle", {
-                      count: boardJobs.length,
-                    })}
-                    palette={palette}
-                  />
-                </View>
-
-                {studioJobs === undefined ? (
-                  <View style={[styles.emptyStateWrap, { minHeight: 320 }]}>
-                    <ActivityIndicator
-                      size="small"
-                      color={
-                        palette.primary as import("react-native").ColorValue
-                      }
-                    />
-                    <ThemedText
-                      style={{
-                        color: palette.textMuted,
-                        marginTop: BrandSpacing.xs,
-                      }}
-                    >
-                      {t("jobsTab.loading")}
-                    </ThemedText>
-                  </View>
-                ) : studioJobs.length === 0 ? (
-                  <View
-                    style={{
-                      flex: 1,
-                      minHeight: 360,
-                      justifyContent: "center",
-                    }}
-                  >
-                    <EmptyState
-                      icon="bag"
-                      title={t("jobsTab.emptyStudio")}
-                      body=""
-                    />
-                  </View>
-                ) : filteredStudioJobs.length === 0 ? (
-                  <View
-                    style={{
-                      flex: 1,
-                      minHeight: 260,
-                      justifyContent: "center",
-                    }}
-                  >
-                    <EmptyState
-                      icon="magnifyingglass"
-                      title={t("jobsTab.noJobsFound")}
-                      body={t("jobsTab.tryDifferentSearchOrTimeFilter")}
-                    />
-                  </View>
-                ) : boardJobs.length > 0 ? (
-                  <StudioJobsList
-                    jobs={boardJobs}
-                    locale={locale}
-                    zoneLanguage={zoneLanguage}
-                    palette={palette}
-                    reviewingApplicationId={isReviewingApplicationId}
-                    payingJobId={isStartingCheckoutForJobId}
-                    onReview={(applicationId, status) => {
-                      void reviewStudioApplication(applicationId, status);
-                    }}
-                    onStartPayment={(jobId) => {
-                      void startStudioCheckout(jobId);
-                    }}
-                    t={t}
-                  />
-                ) : (
-                  <View
-                    style={{
-                      flex: 1,
-                      minHeight: 240,
-                      justifyContent: "center",
-                    }}
-                  >
-                    <EmptyState
-                      icon="checkmark.circle"
-                      title={t("jobsTab.boardEmptyTitle")}
-                      body={t("jobsTab.boardEmptyBody")}
-                    />
-                  </View>
-                )}
-              </View>
-            </View>
-
-            <View style={{ width: 320, gap: 16 }}>
-              <View
-                style={{
-                  borderRadius: 30,
-                  borderCurve: "continuous",
-                  backgroundColor: palette.surface as string,
-                  paddingHorizontal: 18,
-                  paddingVertical: 18,
-                  gap: 12,
-                }}
-              >
-                <FeedSectionHeader
-                  title={t("jobsTab.studioFeed.filterDeskTitle")}
-                  subtitle={t("jobsTab.studioFeed.filterDeskSubtitle")}
-                  palette={palette}
-                />
-                <NativeSearchField
-                  value={jobsSearchQuery}
-                  onChangeText={setJobsSearchQuery}
-                  placeholder={t("jobsTab.searchPlaceholder", {
-                    defaultValue: "Search jobs",
-                  })}
-                  clearAccessibilityLabel={t("common.clear", {
-                    defaultValue: "Clear search",
-                  })}
-                />
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.chipGrid}
-                >
-                  {filterOptions.map((option) => (
-                    <KitChip
-                      key={option.key}
-                      label={option.label}
-                      selected={jobsStatusFilter === option.key}
-                      onPress={() => {
-                        setJobsStatusFilter(
-                          option.key as StudioJobsStatusFilter,
-                        );
-                      }}
-                    />
-                  ))}
-                </ScrollView>
-              </View>
-
-              {studioNotificationSettings !== undefined &&
-              !studioNotificationSettings?.hasExpoPushToken ? (
-                <View
-                  style={{
-                    borderRadius: 30,
-                    borderCurve: "continuous",
-                    backgroundColor: palette.surfaceAlt as string,
-                    paddingHorizontal: 18,
-                    paddingVertical: 18,
-                    gap: 10,
-                  }}
-                >
-                  <FeedSectionHeader
-                    title={t("jobsTab.notificationsTitle")}
-                    subtitle={t("jobsTab.studioPushDescription")}
-                    palette={palette}
-                  />
-                  <ActionButton
-                    label={
-                      isEnablingStudioPush
-                        ? t("jobsTab.actions.enablingPush")
-                        : t("jobsTab.actions.enablePush")
-                    }
-                    palette={palette}
-                    tone="secondary"
-                    onPress={() => {
-                      void enableStudioPush();
-                    }}
-                    disabled={isEnablingStudioPush}
-                  />
-                </View>
-              ) : null}
-
-              <View
-                style={{
-                  borderRadius: 30,
-                  borderCurve: "continuous",
-                  backgroundColor: palette.surfaceAlt as string,
-                  paddingHorizontal: 18,
-                  paddingVertical: 18,
-                  gap: 8,
-                }}
-              >
-                <Text
-                  style={{
-                    ...BrandType.heading,
-                    fontSize: 24,
-                    color: palette.text as string,
-                  }}
-                >
-                  Workflow
-                </Text>
-                <Text
-                  style={{
-                    ...BrandType.caption,
-                    color: palette.textMuted as string,
-                  }}
-                >
-                  Review stays detailed only while a decision is needed. The
-                  board compresses once a job is staffed or settled, so web
-                  reads like an operations desk instead of a long mobile feed.
-                </Text>
-              </View>
-            </View>
-          </View>
-        </TabScreenScrollView>
-
-        {isFocused ? (
-          <CreateJobSheet
-            innerRef={createJobSheetRef as never}
-            palette={palette}
-            isSubmitting={isSubmittingStudio}
-            onClose={() => createJobSheetRef.current?.close()}
-            onPost={postStudioJob}
-          />
-        ) : null}
-      </View>
-    );
-  }
-
   return (
-    <View style={screenStyle}>
+    <View style={[styles.screen, { backgroundColor: palette.appBg }]}>
       <TabScreenScrollView
         routeKey="studio/jobs/index"
         style={styles.screen}
         contentContainerStyle={[
           styles.content,
-          { paddingTop: mobileContentPaddingTop },
+          {
+            paddingTop: mobileContentPaddingTop,
+            paddingHorizontal: BrandSpacing.lg,
+          },
         ]}
         topInsetTone="sheet"
         keyboardShouldPersistTaps="handled"
       >
-        <View>
-          {/* Header removed from Jobs Tab for minimalism */}
+        <View style={styles.page}>
+          <View style={styles.noticeStack}>
+            <FeedSectionHeader
+              title={t("jobsTab.studioFeed.title")}
+              subtitle={t("jobsTab.studioFeed.body")}
+              palette={palette}
+            />
 
-          {errorMessage ? (
-            <View style={styles.noticeWrap}>
+            {errorMessage ? (
               <NoticeBanner
                 tone="error"
                 message={errorMessage}
@@ -641,11 +205,9 @@ export function StudioFeed() {
                 textColor={palette.danger}
                 iconColor={palette.danger}
               />
-            </View>
-          ) : null}
+            ) : null}
 
-          {statusMessage ? (
-            <View style={styles.noticeWrap}>
+            {statusMessage ? (
               <NoticeBanner
                 tone="success"
                 message={statusMessage}
@@ -655,317 +217,145 @@ export function StudioFeed() {
                 textColor={palette.text}
                 iconColor={palette.success as import("react-native").ColorValue}
               />
-            </View>
-          ) : null}
-        </View>
+            ) : null}
+          </View>
 
-        {currentUser.role === "studio" ? (
-          <>
-            <KitSurface
-              tone="sheet"
-              padding={BrandSpacing.lg}
-              gap={BrandSpacing.md}
-              style={{
-                marginHorizontal: BrandSpacing.lg,
-              }}
-            >
-              <View
-                style={{
-                  flexDirection: "row",
-                  gap: 10,
-                }}
+          <KitSurface
+            tone="sheet"
+            padding={BrandSpacing.lg}
+            gap={BrandSpacing.md}
+          >
+            <View style={styles.controlHeader}>
+              <ThemedText
+                type="meta"
+                style={{ color: palette.textMuted as string }}
               >
                 {[
-                  {
-                    label: "Open",
-                    value: String(
-                      studioJobs?.filter(
-                        (job: StudioFeedJobSummary) => job.status === "open",
-                      ).length ?? 0,
-                    ),
-                    accent: palette.primary as string,
-                  },
-                  {
-                    label: "Review",
-                    value: String(
-                      studioJobs?.reduce(
-                        (total: number, job: StudioFeedJobSummary) =>
-                          total + job.pendingApplicationsCount,
-                        0,
-                      ) ?? 0,
-                    ),
-                  },
-                  {
-                    label: "Filled",
-                    value: String(
-                      studioJobs?.filter(
-                        (job: StudioFeedJobSummary) => job.status === "filled",
-                      ).length ?? 0,
-                    ),
-                    accent: palette.success as string,
-                  },
-                ].map((item) => (
-                  <View
-                    key={item.label}
-                    style={{
-                      flex: 1,
-                      gap: 4,
-                      borderRadius: BrandRadius.card,
-                      borderCurve: "continuous",
-                      backgroundColor: palette.surface as string,
-                      paddingHorizontal: BrandSpacing.md,
-                      paddingVertical: BrandSpacing.md,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        ...BrandType.caption,
-                        color: palette.textMuted as string,
-                      }}
-                    >
-                      {item.label}
-                    </Text>
-                    <Text
-                      style={{
-                        ...BrandType.title,
-                        color: item.accent ?? (palette.text as string),
-                        fontVariant: ["tabular-nums"],
-                      }}
-                    >
-                      {item.value}
-                    </Text>
-                  </View>
-                ))}
-              </View>
+                  `${t("jobsTab.studioFeed.metricReview")}: ${String(reviewCount)}`,
+                  `${t("jobsTab.studioFeed.metricOpen")}: ${String(openCount)}`,
+                  `${t("jobsTab.studioFeed.metricFilled")}: ${String(filledCount)}`,
+                ].join("  •  ")}
+              </ThemedText>
 
-              <View
-                style={{
-                  borderRadius: BrandRadius.card,
-                  borderCurve: "continuous",
-                  backgroundColor: palette.surface as string,
-                  padding: 18,
-                  gap: 14,
-                }}
-              >
-                <View style={{ gap: 4 }}>
-                  <Text
-                    style={{
-                      ...BrandType.micro,
-                      color: palette.textMuted as string,
-                    }}
-                  >
-                    Operations
-                  </Text>
-                  <Text
-                    style={{
-                      ...BrandType.title,
-                      fontSize: 24,
-                      lineHeight: 30,
-                      color: palette.text as string,
-                    }}
-                  >
-                    {jobsStatusFilter === "needs_review"
-                      ? "Work the applicant queue"
-                      : "Post fast, fill faster"}
-                  </Text>
-                  <Text
-                    style={{
-                      ...BrandType.caption,
-                      color: palette.textMuted as string,
-                    }}
-                  >
-                    Create shifts, review applicants, and move payment work from
-                    one lane.
-                  </Text>
-                </View>
+              <View style={styles.actionRow}>
                 <ActionButton
                   label={t("jobsTab.form.title", "Post New Job")}
                   onPress={() => createJobSheetRef.current?.expand()}
                   palette={palette}
                 />
-              </View>
-            </KitSurface>
-
-            {studioNotificationSettings !== undefined &&
-            !studioNotificationSettings?.hasExpoPushToken ? (
-              <View
-                style={[styles.section, { borderBottomColor: "transparent" }]}
-              >
-                <FeedSectionHeader
-                  title={t("jobsTab.notificationsTitle")}
-                  subtitle={t("jobsTab.studioPushDescription")}
-                  palette={palette}
-                />
-                <View style={styles.settingRow}>
-                  <View style={styles.settingCopy}>
-                    <ThemedText style={{ color: palette.textMuted }}>
-                      {t("jobsTab.studioPushDescription")}
-                    </ThemedText>
-                  </View>
+                {reviewCount > 0 ? (
                   <ActionButton
-                    label={
-                      isEnablingStudioPush
-                        ? t("jobsTab.actions.enablingPush")
-                        : t("jobsTab.actions.enablePush")
-                    }
+                    label={t("jobsTab.studioFeed.reviewAction", {
+                      count: reviewCount,
+                    })}
+                    onPress={() => setJobsStatusFilter("needs_review")}
                     palette={palette}
                     tone="secondary"
-                    onPress={() => {
-                      void enableStudioPush();
-                    }}
-                    disabled={isEnablingStudioPush}
                   />
-                </View>
+                ) : null}
               </View>
-            ) : null}
+            </View>
 
-            <View style={{ flex: 1, paddingTop: BrandSpacing.md }}>
+            <NativeSearchField
+              value={jobsSearchQuery}
+              onChangeText={setJobsSearchQuery}
+              placeholder={t("jobsTab.searchPlaceholder", {
+                defaultValue: "Search jobs",
+              })}
+              clearAccessibilityLabel={t("common.clear", {
+                defaultValue: "Clear search",
+              })}
+            />
+
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.chipGrid}
+            >
+              {filterOptions.map((option) => (
+                <KitChip
+                  key={option.key}
+                  label={option.label}
+                  selected={jobsStatusFilter === option.key}
+                  onPress={() => {
+                    setJobsStatusFilter(option.key as StudioJobsStatusFilter);
+                  }}
+                />
+              ))}
+            </ScrollView>
+          </KitSurface>
+
+          {studioNotificationSettings != null &&
+          !studioNotificationSettings.hasExpoPushToken ? (
+            <KitSurface
+              tone="sheet"
+              padding={BrandSpacing.lg}
+              gap={BrandSpacing.md}
+            >
               <FeedSectionHeader
-                title={
-                  shouldSplitMobileBoard
-                    ? t("jobsTab.studioFeed.mobileSplitTitle")
-                    : jobsStatusFilter === "needs_review"
-                      ? t("jobsTab.studioFeed.needsReviewTitle")
-                      : t("jobsTab.studioFeed.boardTitle")
-                }
-                subtitle={
-                  shouldSplitMobileBoard
-                    ? t("jobsTab.studioFeed.mobileSplitSubtitle")
-                    : jobsStatusFilter === "needs_review"
-                      ? t("jobsTab.studioFeed.mobileNeedsReviewSubtitle")
-                      : t("jobsTab.studioApplicationsTitle")
-                }
+                title={t("jobsTab.notificationsTitle")}
+                subtitle={t("jobsTab.studioPushDescription")}
                 palette={palette}
               />
-              <View
+              <ActionButton
+                label={
+                  isEnablingStudioPush
+                    ? t("jobsTab.actions.enablingPush")
+                    : t("jobsTab.actions.enablePush")
+                }
+                palette={palette}
+                tone="secondary"
+                onPress={() => {
+                  void enableStudioPush();
+                }}
+                disabled={isEnablingStudioPush}
+              />
+            </KitSurface>
+          ) : null}
+
+          {studioJobs === undefined ? (
+            <View style={[styles.emptyStateWrap, { minHeight: 300 }]}>
+              <ActivityIndicator
+                size="small"
+                color={palette.primary as import("react-native").ColorValue}
+              />
+              <ThemedText
                 style={{
-                  paddingHorizontal: BrandSpacing.lg,
-                  gap: BrandSpacing.sm,
-                  paddingBottom: BrandSpacing.sm,
+                  color: palette.textMuted,
+                  marginTop: BrandSpacing.xs,
                 }}
               >
-                <NativeSearchField
-                  value={jobsSearchQuery}
-                  onChangeText={setJobsSearchQuery}
-                  placeholder={t("jobsTab.searchPlaceholder", {
-                    defaultValue: "Search jobs",
+                {t("jobsTab.loading")}
+              </ThemedText>
+            </View>
+          ) : studioJobs.length === 0 ? (
+            <View style={{ minHeight: 320, justifyContent: "center" }}>
+              <EmptyState icon="bag" title={t("jobsTab.emptyStudio")} body="" />
+            </View>
+          ) : filteredStudioJobs.length === 0 ? (
+            <View style={{ minHeight: 260, justifyContent: "center" }}>
+              <EmptyState
+                icon="magnifyingglass"
+                title={t("jobsTab.noJobsFound")}
+                body={t("jobsTab.tryDifferentSearchOrTimeFilter")}
+              />
+            </View>
+          ) : shouldSplitBoard ? (
+            <View style={styles.sectionStack}>
+              <KitSurface
+                tone="sheet"
+                padding={BrandSpacing.lg}
+                gap={BrandSpacing.md}
+              >
+                <FeedSectionHeader
+                  title={t("jobsTab.studioFeed.needsReviewTitle")}
+                  subtitle={t("jobsTab.studioFeed.mobileDecisionWaiting", {
+                    count: reviewQueueJobs.length,
                   })}
-                  clearAccessibilityLabel={t("common.clear", {
-                    defaultValue: "Clear search",
-                  })}
+                  palette={palette}
                 />
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.chipGrid}
-                >
-                  {filterOptions.map((option) => {
-                    const selected = jobsStatusFilter === option.key;
-                    return (
-                      <KitChip
-                        key={option.key}
-                        label={option.label}
-                        selected={selected}
-                        onPress={() => {
-                          setJobsStatusFilter(
-                            option.key as StudioJobsStatusFilter,
-                          );
-                        }}
-                      />
-                    );
-                  })}
-                </ScrollView>
-              </View>
-              {studioJobs === undefined ? (
-                <View style={[styles.emptyStateWrap, { minHeight: 300 }]}>
-                  <ActivityIndicator
-                    size="small"
-                    color={palette.primary as import("react-native").ColorValue}
-                  />
-                  <ThemedText
-                    style={{
-                      color: palette.textMuted,
-                      marginTop: BrandSpacing.xs,
-                    }}
-                  >
-                    {t("jobsTab.loading")}
-                  </ThemedText>
-                </View>
-              ) : studioJobs.length === 0 ? (
-                <View
-                  style={{ flex: 1, minHeight: 400, justifyContent: "center" }}
-                >
-                  <EmptyState
-                    icon="bag"
-                    title={t("jobsTab.emptyStudio")}
-                    body=""
-                  />
-                </View>
-              ) : filteredStudioJobs.length === 0 ? (
-                <View
-                  style={{ flex: 1, minHeight: 260, justifyContent: "center" }}
-                >
-                  <EmptyState
-                    icon="magnifyingglass"
-                    title={t("jobsTab.noJobsFound")}
-                    body={t("jobsTab.tryDifferentSearchOrTimeFilter")}
-                  />
-                </View>
-              ) : shouldSplitMobileBoard ? (
-                <View style={{ gap: BrandSpacing.md }}>
-                  <View style={{ gap: BrandSpacing.xs }}>
-                    <FeedSectionHeader
-                      title={t("jobsTab.studioFeed.needsReviewTitle")}
-                      subtitle={t("jobsTab.studioFeed.mobileDecisionWaiting", {
-                        count: reviewQueueJobs.length,
-                      })}
-                      palette={palette}
-                    />
-                    <StudioJobsList
-                      jobs={reviewQueueJobs}
-                      locale={locale}
-                      zoneLanguage={zoneLanguage}
-                      palette={palette}
-                      reviewingApplicationId={isReviewingApplicationId}
-                      payingJobId={isStartingCheckoutForJobId}
-                      onReview={(applicationId, status) => {
-                        void reviewStudioApplication(applicationId, status);
-                      }}
-                      onStartPayment={(jobId) => {
-                        void startStudioCheckout(jobId);
-                      }}
-                      t={t}
-                    />
-                  </View>
-
-                  <View style={{ gap: BrandSpacing.xs }}>
-                    <FeedSectionHeader
-                      title={t("jobsTab.studioFeed.boardTitle")}
-                      subtitle={t("jobsTab.studioFeed.boardSubtitle", {
-                        count: boardJobs.length,
-                      })}
-                      palette={palette}
-                    />
-                    <StudioJobsList
-                      jobs={boardJobs}
-                      locale={locale}
-                      zoneLanguage={zoneLanguage}
-                      palette={palette}
-                      reviewingApplicationId={isReviewingApplicationId}
-                      payingJobId={isStartingCheckoutForJobId}
-                      onReview={(applicationId, status) => {
-                        void reviewStudioApplication(applicationId, status);
-                      }}
-                      onStartPayment={(jobId) => {
-                        void startStudioCheckout(jobId);
-                      }}
-                      t={t}
-                    />
-                  </View>
-                </View>
-              ) : (
                 <StudioJobsList
-                  jobs={mobilePrimaryJobs}
+                  jobs={reviewQueueJobs}
                   locale={locale}
                   zoneLanguage={zoneLanguage}
                   palette={palette}
@@ -979,10 +369,76 @@ export function StudioFeed() {
                   }}
                   t={t}
                 />
-              )}
+              </KitSurface>
+
+              <KitSurface
+                tone="sheet"
+                padding={BrandSpacing.lg}
+                gap={BrandSpacing.md}
+              >
+                <FeedSectionHeader
+                  title={t("jobsTab.studioFeed.boardTitle")}
+                  subtitle={t("jobsTab.studioFeed.boardSubtitle", {
+                    count: boardJobs.length,
+                  })}
+                  palette={palette}
+                />
+                <StudioJobsList
+                  jobs={boardJobs}
+                  locale={locale}
+                  zoneLanguage={zoneLanguage}
+                  palette={palette}
+                  reviewingApplicationId={isReviewingApplicationId}
+                  payingJobId={isStartingCheckoutForJobId}
+                  onReview={(applicationId, status) => {
+                    void reviewStudioApplication(applicationId, status);
+                  }}
+                  onStartPayment={(jobId) => {
+                    void startStudioCheckout(jobId);
+                  }}
+                  t={t}
+                />
+              </KitSurface>
             </View>
-          </>
-        ) : null}
+          ) : (
+            <KitSurface
+              tone="sheet"
+              padding={BrandSpacing.lg}
+              gap={BrandSpacing.md}
+            >
+              <FeedSectionHeader
+                title={primarySectionTitle}
+                subtitle={primarySectionSubtitle}
+                palette={palette}
+              />
+              {primaryJobs.length > 0 ? (
+                <StudioJobsList
+                  jobs={primaryJobs}
+                  locale={locale}
+                  zoneLanguage={zoneLanguage}
+                  palette={palette}
+                  reviewingApplicationId={isReviewingApplicationId}
+                  payingJobId={isStartingCheckoutForJobId}
+                  onReview={(applicationId, status) => {
+                    void reviewStudioApplication(applicationId, status);
+                  }}
+                  onStartPayment={(jobId) => {
+                    void startStudioCheckout(jobId);
+                  }}
+                  t={t}
+                />
+              ) : (
+                <View style={{ minHeight: 220, justifyContent: "center" }}>
+                  <EmptyState
+                    icon="checkmark.circle"
+                    title={t("jobsTab.boardEmptyTitle")}
+                    body={t("jobsTab.boardEmptyBody")}
+                  />
+                </View>
+              )}
+            </KitSurface>
+          )}
+        </View>
       </TabScreenScrollView>
 
       {isFocused ? (
@@ -1004,138 +460,28 @@ const styles = StyleSheet.create({
   },
   content: {
     flexGrow: 1,
+    paddingBottom: BrandSpacing.xl,
   },
-  noticeWrap: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
-  },
-  heroWrap: {
-    gap: 8,
-    paddingBottom: 8,
-  },
-  heroMetricsRow: {
-    flexDirection: "row",
-    gap: 12,
-    alignItems: "center",
-  },
-  heroMetricCol: {
+  page: {
     flex: 1,
-    gap: 2,
+    gap: BrandSpacing.lg,
+  },
+  noticeStack: {
+    gap: BrandSpacing.sm,
   },
   sectionHeader: {
     gap: 2,
   },
-  section: {
-    borderBottomWidth: 1,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    gap: 12,
+  controlHeader: {
+    gap: BrandSpacing.sm,
   },
-  formStepSection: {
-    borderWidth: 1,
-    borderRadius: 14,
-    borderCurve: "continuous",
-    padding: 12,
-    gap: 10,
-  },
-  formStepHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-  },
-  formStepBadge: {
-    minWidth: 36,
-    borderWidth: 1,
-    borderRadius: 999,
-    borderCurve: "continuous",
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-  },
-  sectionBlock: {
-    gap: 10,
-  },
-  compactAction: {
-    borderWidth: 1,
-    borderRadius: 999,
-    borderCurve: "continuous",
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    alignSelf: "flex-start",
-  },
-  lessonSheet: {
-    borderBottomWidth: 1,
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    gap: 8,
-  },
-  focusStickyWrap: {
-    zIndex: 2,
-  },
-  snapshotSection: {
-    borderBottomWidth: 1,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  snapshotGrid: {
+  actionRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 8,
   },
-  snapshotTile: {
-    minWidth: 120,
-    flexGrow: 1,
-    borderWidth: 1,
-    borderRadius: 12,
-    borderCurve: "continuous",
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    gap: 4,
-  },
-  snapshotValue: {
-    fontSize: 20,
-    fontWeight: "600",
-    lineHeight: 24,
-  },
-  lessonHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "flex-start",
-    gap: 10,
-  },
-  lessonCopy: {
-    flex: 1,
-    gap: 2,
-  },
-  lessonMeta: {
-    alignItems: "flex-end",
-    gap: 2,
-  },
-  lessonTimingText: {
-    fontVariant: ["tabular-nums"],
-    fontWeight: "500",
-  },
-  progressTrack: {
-    width: "100%",
-    height: 8,
-    borderRadius: 999,
-    overflow: "hidden",
-  },
-  progressFill: {
-    height: "100%",
-    borderRadius: 999,
-  },
-  jobsFeed: {
-    borderBottomWidth: 1,
-  },
-  jobsFeedHeader: {
-    borderBottomWidth: 1,
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
+  sectionStack: {
+    gap: BrandSpacing.lg,
   },
   emptyStateWrap: {
     paddingHorizontal: 16,
@@ -1144,123 +490,8 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     gap: 10,
   },
-  emptyStateText: {
-    textAlign: "center",
-  },
-  jobRow: {
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-    gap: 8,
-  },
-  jobPrimaryCopy: {
-    flex: 1,
-    gap: 2,
-  },
-  jobFooterRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 10,
-  },
-  rowActionButton: {
-    minHeight: 36,
-    borderWidth: 1,
-    borderRadius: 999,
-    borderCurve: "continuous",
-    paddingHorizontal: 14,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  archiveRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingTop: 10,
-    gap: 8,
-  },
-  archiveCopy: {
-    flex: 1,
-    gap: 2,
-  },
-  feedRow: {
-    paddingTop: 12,
-    gap: 8,
-  },
-  applicationRow: {
-    borderTopWidth: 1,
-    paddingTop: 8,
-    gap: 6,
-  },
   chipGrid: {
     flexDirection: "row",
-    flexWrap: "wrap",
     gap: 8,
-  },
-  timeCardRow: {
-    flexDirection: "row",
-    gap: 8,
-  },
-  timeField: {
-    flex: 1,
-    borderWidth: 1,
-    borderRadius: 14,
-    borderCurve: "continuous",
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    gap: 4,
-  },
-  inlinePickerWrap: {
-    borderWidth: 1,
-    borderRadius: 12,
-    borderCurve: "continuous",
-    padding: 10,
-    gap: 8,
-  },
-  noteInput: {
-    minHeight: 100,
-    textAlignVertical: "top",
-    paddingTop: 12,
-  },
-  settingRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 10,
-  },
-  settingCopy: {
-    flex: 1,
-    gap: 2,
-  },
-  stepperWrap: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderWidth: 1,
-    borderRadius: 999,
-    borderCurve: "continuous",
-  },
-  stepperButton: {
-    minWidth: 38,
-    minHeight: 38,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 6,
-  },
-  stepperValue: {
-    minWidth: 36,
-    textAlign: "center",
-    fontVariant: ["tabular-nums"],
-  },
-  jobHeaderRow: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    justifyContent: "space-between",
-    gap: 8,
-  },
-  actionRow: {
-    flexDirection: "row",
-    gap: 8,
-  },
-  actionButton: {
-    flex: 1,
   },
 });


### PR DESCRIPTION
## Summary
- flatten instructor and studio jobs feeds into one list-first layout per role
- remove wide-web hero panels, metric rails, workflow blocks, and duplicate mobile ops chrome
- log the executed slice in the brutal audit doc

## Verification
- bun run typecheck