### PR TITLE
UI Cut 05: simplify shared actions and job sheet controls

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -508,6 +508,12 @@ Replace with consequence and momentum:
 - made sign-in lead with email first instead of giving every auth method equal weight
 - reduced onboarding action plumbing to simpler native-style buttons and clearer next/back flows
 
+### Slice 05
+
+- removed kit action wrappers from the create-job sheet and small shared controls
+- simplified dismiss and clear interactions to plain native pressables
+- trimmed over-authored create-job copy so the sheet gets to the point faster
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/components/jobs/notice-banner.tsx
+++ b/src/components/jobs/notice-banner.tsx
@@ -1,8 +1,13 @@
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { type ColorValue, StyleSheet, View, type ViewStyle } from "react-native";
+import {
+  type ColorValue,
+  Pressable,
+  StyleSheet,
+  View,
+  type ViewStyle,
+} from "react-native";
 
 import { ThemedText } from "@/components/themed-text";
-import { KitPressable } from "@/components/ui/kit";
 
 type NoticeBannerProps = {
   tone: "success" | "error";
@@ -38,16 +43,17 @@ export function NoticeBanner({
       <ThemedText selectable style={[styles.copy, { color: textColor }]}>
         {message}
       </ThemedText>
-      <KitPressable
+      <Pressable
         hitSlop={8}
         onPress={onDismiss}
-        style={styles.dismiss}
         accessibilityRole="button"
-        nativeFeedback={false}
-        pressedOpacity={0.7}
+        style={({ pressed }) => [
+          styles.dismiss,
+          { opacity: pressed ? 0.7 : 1 },
+        ]}
       >
         <MaterialIcons name="close" size={16} color={textColor} />
-      </KitPressable>
+      </Pressable>
     </View>
   );
 }

--- a/src/components/jobs/studio/create-job-sheet.tsx
+++ b/src/components/jobs/studio/create-job-sheet.tsx
@@ -1,15 +1,23 @@
-import BottomSheet, { BottomSheetBackdrop, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetScrollView,
+} from "@gorhom/bottom-sheet";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import type React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Platform, ScrollView, StyleSheet, View } from "react-native";
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
 
 import { ThemedText } from "@/components/themed-text";
 import { AppSymbol } from "@/components/ui/app-symbol";
-import { KitButton } from "@/components/ui/kit/kit-button";
+import { ActionButton } from "@/components/ui/action-button";
 import { KitChip } from "@/components/ui/kit/kit-chip";
-import { KitPressable } from "@/components/ui/kit/kit-pressable";
 import { KitTextField } from "@/components/ui/kit/kit-text-field";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandRadius, BrandSpacing } from "@/constants/brand";
@@ -49,7 +57,12 @@ export function CreateJobSheet({
 
   const renderBackdrop = useCallback(
     (props: any) => (
-      <BottomSheetBackdrop {...props} disappearsAt={-1} appearsAt={0} opacity={0.5} />
+      <BottomSheetBackdrop
+        {...props}
+        disappearsAt={-1}
+        appearsAt={0}
+        opacity={0.5}
+      />
     ),
     [],
   );
@@ -126,22 +139,27 @@ export function CreateJobSheet({
     >
       <BottomSheetScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.header}>
-          <View style={{ gap: 4 }}>
-            <ThemedText type="micro" style={{ color: palette.textMuted as string }}>
-              STUDIO COMMAND
-            </ThemedText>
-            <ThemedText type="title" style={{ fontSize: 28 }}>
-              {t("jobsTab.form.title", "Post New Job")}
-            </ThemedText>
-          </View>
-          <KitPressable
+          <ThemedText type="title" style={{ fontSize: 28 }}>
+            {t("jobsTab.form.title", "Post New Job")}
+          </ThemedText>
+          <Pressable
             accessibilityRole="button"
             accessibilityLabel={t("common.close", { defaultValue: "Close" })}
             onPress={handleCloseSheet}
-            style={[styles.closeButton, { backgroundColor: palette.surfaceAlt as string }]}
+            style={({ pressed }) => [
+              styles.closeButton,
+              {
+                backgroundColor: palette.surfaceAlt as string,
+                opacity: pressed ? 0.72 : 1,
+              },
+            ]}
           >
-            <AppSymbol name="xmark" size={18} tintColor={palette.textMuted as string} />
-          </KitPressable>
+            <AppSymbol
+              name="xmark"
+              size={18}
+              tintColor={palette.textMuted as string}
+            />
+          </Pressable>
         </View>
 
         <View style={styles.form}>
@@ -155,9 +173,6 @@ export function CreateJobSheet({
               gap: 10,
             }}
           >
-            <ThemedText type="micro" style={{ color: palette.textMuted as string }}>
-              SHIFT SNAPSHOT
-            </ThemedText>
             <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
               {[
                 draft.sport ? toSportLabel(draft.sport as never) : "Pick sport",
@@ -174,7 +189,10 @@ export function CreateJobSheet({
                     paddingVertical: 8,
                   }}
                 >
-                  <ThemedText type="micro" style={{ color: palette.text as string }}>
+                  <ThemedText
+                    type="micro"
+                    style={{ color: palette.text as string }}
+                  >
                     {item}
                   </ThemedText>
                 </View>
@@ -216,47 +234,60 @@ export function CreateJobSheet({
             </ThemedText>
 
             <View style={styles.row}>
-              <KitPressable
+              <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t("jobsTab.form.schedule", "Schedule")}
                 onPress={() => setShowDatePicker(true)}
-                style={[
+                style={({ pressed }) => [
                   styles.pickerTrigger,
                   {
                     backgroundColor: palette.surfaceAlt as string,
+                    opacity: pressed ? 0.78 : 1,
                   },
                 ]}
               >
-                <AppSymbol name="calendar" size={16} tintColor={palette.primary as string} />
+                <AppSymbol
+                  name="calendar"
+                  size={16}
+                  tintColor={palette.primary as string}
+                />
                 <ThemedText style={styles.pickerText}>
                   {formatDateWithWeekday(draft.startTime, locale)}
                 </ThemedText>
-              </KitPressable>
+              </Pressable>
             </View>
 
             <View style={[styles.row, { marginTop: 12 }]}>
-              <KitPressable
+              <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t("jobsTab.form.startTime")}
                 onPress={() => setShowStartTimePicker(true)}
-                style={[
+                style={({ pressed }) => [
                   styles.pickerTrigger,
                   {
                     flex: 1,
                     backgroundColor: palette.surfaceAlt as string,
+                    opacity: pressed ? 0.78 : 1,
                   },
                 ]}
               >
-                <AppSymbol name="clock" size={16} tintColor={palette.primary as string} />
+                <AppSymbol
+                  name="clock"
+                  size={16}
+                  tintColor={palette.primary as string}
+                />
                 <View>
-                  <ThemedText type="micro" style={{ color: palette.textMuted as string }}>
+                  <ThemedText
+                    type="micro"
+                    style={{ color: palette.textMuted as string }}
+                  >
                     {t("jobsTab.form.startTime")}
                   </ThemedText>
                   <ThemedText style={styles.pickerText}>
                     {formatTime(draft.startTime, locale)}
                   </ThemedText>
                 </View>
-              </KitPressable>
+              </Pressable>
 
               <View
                 style={{
@@ -265,31 +296,43 @@ export function CreateJobSheet({
                   justifyContent: "center",
                 }}
               >
-                <AppSymbol name="arrow.right" size={12} tintColor={palette.textMuted as string} />
+                <AppSymbol
+                  name="arrow.right"
+                  size={12}
+                  tintColor={palette.textMuted as string}
+                />
               </View>
 
-              <KitPressable
+              <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t("jobsTab.form.endTime")}
                 onPress={() => setShowEndTimePicker(true)}
-                style={[
+                style={({ pressed }) => [
                   styles.pickerTrigger,
                   {
                     flex: 1,
                     backgroundColor: palette.surfaceAlt as string,
+                    opacity: pressed ? 0.78 : 1,
                   },
                 ]}
               >
-                <AppSymbol name="clock" size={16} tintColor={palette.primary as string} />
+                <AppSymbol
+                  name="clock"
+                  size={16}
+                  tintColor={palette.primary as string}
+                />
                 <View>
-                  <ThemedText type="micro" style={{ color: palette.textMuted as string }}>
+                  <ThemedText
+                    type="micro"
+                    style={{ color: palette.textMuted as string }}
+                  >
                     {t("jobsTab.form.endTime")}
                   </ThemedText>
                   <ThemedText style={styles.pickerText}>
                     {formatTime(draft.endTime, locale)}
                   </ThemedText>
                 </View>
-              </KitPressable>
+              </Pressable>
             </View>
           </View>
 
@@ -299,7 +342,9 @@ export function CreateJobSheet({
               <KitTextField
                 label={t("jobsTab.form.pay", "Pay (₪)")}
                 value={draft.payInput}
-                onChangeText={(v) => setDraft((d) => ({ ...d, payInput: sanitizeDecimalInput(v) }))}
+                onChangeText={(v) =>
+                  setDraft((d) => ({ ...d, payInput: sanitizeDecimalInput(v) }))
+                }
                 keyboardType="decimal-pad"
                 placeholder="250"
               />
@@ -332,11 +377,17 @@ export function CreateJobSheet({
           />
 
           <View style={{ marginTop: 24, paddingBottom: 40 }}>
-            <KitButton
-              label={isSubmitting ? t("jobsTab.actions.posting") : t("jobsTab.actions.post")}
+            <ActionButton
+              label={
+                isSubmitting
+                  ? t("jobsTab.actions.posting")
+                  : t("jobsTab.actions.post")
+              }
               onPress={() => onPost(draft)}
               disabled={isSubmitting || !draft.sport}
+              palette={palette}
               loading={isSubmitting}
+              fullWidth
             />
           </View>
         </View>
@@ -353,11 +404,11 @@ export function CreateJobSheet({
             minimumDate={new Date()}
           />
           {Platform.OS === "ios" ? (
-            <KitButton
+            <ActionButton
               label={t("common.done", { defaultValue: "Done" })}
               onPress={() => setShowDatePicker(false)}
-              variant="secondary"
-              size="sm"
+              palette={palette}
+              tone="secondary"
             />
           ) : null}
         </View>
@@ -371,11 +422,11 @@ export function CreateJobSheet({
             onChange={handleStartTimeChange}
           />
           {Platform.OS === "ios" ? (
-            <KitButton
+            <ActionButton
               label={t("common.done", { defaultValue: "Done" })}
               onPress={() => setShowStartTimePicker(false)}
-              variant="secondary"
-              size="sm"
+              palette={palette}
+              tone="secondary"
             />
           ) : null}
         </View>
@@ -390,11 +441,11 @@ export function CreateJobSheet({
             minimumDate={new Date(draft.startTime)}
           />
           {Platform.OS === "ios" ? (
-            <KitButton
+            <ActionButton
               label={t("common.done", { defaultValue: "Done" })}
               onPress={() => setShowEndTimePicker(false)}
-              variant="secondary"
-              size="sm"
+              palette={palette}
+              tone="secondary"
             />
           ) : null}
         </View>

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -4,14 +4,12 @@ import Animated, { FadeIn } from "react-native-reanimated";
 
 import { ThemedText } from "@/components/themed-text";
 import { AppSymbol } from "@/components/ui/app-symbol";
-import { KitButton } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
 import { BrandSpacing } from "@/constants/brand";
 import { useBrand } from "@/hooks/use-brand";
 
 type EmptyStateAction = {
   label: string;
-  /** SF Symbol name - optional; button renders without icon if absent. */
-  icon?: SymbolViewProps["name"];
   onPress: () => void;
 };
 
@@ -32,7 +30,7 @@ type EmptyStateProps = {
  *   icon="calendar.badge.exclamationmark"
  *   title="Nothing booked yet"
  *   body="18 open jobs match your zone right now."
- *   action={{ label: "Browse Jobs", icon: "briefcase", onPress: () => router.push('/jobs') }}
+ *   action={{ label: "Browse Jobs", onPress: () => router.push('/jobs') }}
  * />
  */
 export function EmptyState({ icon, title, body, action }: EmptyStateProps) {
@@ -49,9 +47,17 @@ export function EmptyState({ icon, title, body, action }: EmptyStateProps) {
         paddingVertical: BrandSpacing.xxl,
       }}
     >
-      <AppSymbol name={icon} size={52} tintColor={palette.textMicro as string} />
+      <AppSymbol
+        name={icon}
+        size={52}
+        tintColor={palette.textMicro as string}
+      />
       <View style={{ gap: BrandSpacing.xs, alignItems: "center" }}>
-        <ThemedText type="title" style={{ textAlign: "center", color: palette.text }} selectable>
+        <ThemedText
+          type="title"
+          style={{ textAlign: "center", color: palette.text }}
+          selectable
+        >
           {title}
         </ThemedText>
         {body ? (
@@ -65,10 +71,10 @@ export function EmptyState({ icon, title, body, action }: EmptyStateProps) {
         ) : null}
       </View>
       {action ? (
-        <KitButton
+        <ActionButton
           label={action.label}
-          {...(action.icon !== undefined ? { icon: action.icon } : {})}
           onPress={action.onPress}
+          palette={palette}
         />
       ) : null}
     </Animated.View>

--- a/src/components/ui/native-search-field.tsx
+++ b/src/components/ui/native-search-field.tsx
@@ -1,6 +1,5 @@
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import { TextInput, type TextInputProps, View } from "react-native";
-import { KitPressable } from "@/components/ui/kit";
+import { Pressable, TextInput, type TextInputProps, View } from "react-native";
 import { BrandRadius } from "@/constants/brand";
 import { useBrand } from "@/hooks/use-brand";
 
@@ -34,7 +33,11 @@ export function NativeSearchField({
         gap: 10,
       }}
     >
-      <MaterialIcons name="search" size={19} color={palette.textMuted as string} />
+      <MaterialIcons
+        name="search"
+        size={19}
+        color={palette.textMuted as string}
+      />
       <TextInput
         value={value}
         onChangeText={onChangeText}
@@ -61,16 +64,19 @@ export function NativeSearchField({
         {...rest}
       />
       {value.length > 0 ? (
-        <KitPressable
+        <Pressable
           accessibilityRole="button"
           accessibilityLabel={clearAccessibilityLabel}
           onPress={() => onChangeText("")}
           hitSlop={8}
-          rippleRadius={16}
           style={({ pressed }) => ({ opacity: pressed ? 0.65 : 1 })}
         >
-          <MaterialIcons name="close" size={18} color={palette.textMuted as string} />
-        </KitPressable>
+          <MaterialIcons
+            name="close"
+            size={18}
+            color={palette.textMuted as string}
+          />
+        </Pressable>
       ) : null}
     </View>
   );


### PR DESCRIPTION
## Summary
- remove kit action wrappers from the create-job sheet and shared dismiss/clear controls
- swap EmptyState CTA to ActionButton and simplify NoticeBanner and NativeSearchField press behavior
- trim the create-job sheet header tone so it gets to the point faster

## Verification
- bun run typecheck
- confirmed no KitButton or KitPressable references remain in the touched files