### PR TITLE
UI Cut 06: simplify profile action surfaces

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -514,6 +514,12 @@ Replace with consequence and momentum:
 - simplified dismiss and clear interactions to plain native pressables
 - trimmed over-authored create-job copy so the sheet gets to the point faster
 
+### Slice 06
+
+- removed kit action wrappers from the reusable profile surfaces
+- simplified profile editor, readiness, and sports-selection controls without changing the route structure yet
+- kept the profile cleanup focused on shared components so later route cuts can delete more safely
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/components/profile/profile-editor-form.tsx
+++ b/src/components/profile/profile-editor-form.tsx
@@ -1,6 +1,12 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ScrollView, Text, type TextInputProps, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  Text,
+  type TextInputProps,
+  View,
+} from "react-native";
 import { useLayoutBreakpoint } from "@/hooks/use-layout-breakpoint";
 
 import {
@@ -9,7 +15,8 @@ import {
   type ProfileSocialLinks,
 } from "@/components/profile/profile-social-links";
 import { SportsMultiSelect } from "@/components/profile/sports-multi-select";
-import { KitButton, KitSurface, KitTextField } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
+import { KitSurface, KitTextField } from "@/components/ui/kit";
 import { ProfileAvatar } from "@/components/ui/profile-avatar";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandSpacing, BrandType } from "@/constants/brand";
@@ -75,25 +82,35 @@ export function ProfileEditorForm({
   const { t } = useTranslation();
   const activeSocialCount = useMemo(
     () =>
-      PROFILE_SOCIAL_FIELDS.filter((field) => Boolean(socialLinksDraft[field.key]?.trim())).length,
+      PROFILE_SOCIAL_FIELDS.filter((field) =>
+        Boolean(socialLinksDraft[field.key]?.trim()),
+      ).length,
     [socialLinksDraft],
   );
-  const [showSocialFields, setShowSocialFields] = useState(activeSocialCount > 0);
+  const [showSocialFields, setShowSocialFields] = useState(
+    activeSocialCount > 0,
+  );
   const saveActions = (
     <View style={{ flexDirection: "row", gap: 12 }}>
       <View style={{ flex: 1 }}>
-        <KitButton
-          label={isSaving ? t("profile.editor.saving") : t("profile.editor.save")}
+        <ActionButton
+          label={
+            isSaving ? t("profile.editor.saving") : t("profile.editor.save")
+          }
           onPress={onSave}
           disabled={isSaving}
+          palette={palette}
+          fullWidth
         />
       </View>
       <View style={{ flex: 1 }}>
-        <KitButton
+        <ActionButton
           label={t("profile.editor.cancel")}
           onPress={onCancel}
-          variant="secondary"
           disabled={isSaving}
+          palette={palette}
+          tone="secondary"
+          fullWidth
         />
       </View>
     </View>
@@ -125,7 +142,9 @@ export function ProfileEditorForm({
             style={{
               ...BrandType.bodyMedium,
               fontSize: 13,
-              color: isDesktopWeb ? (palette.onPrimary as string) : (palette.textMuted as string),
+              color: isDesktopWeb
+                ? (palette.onPrimary as string)
+                : (palette.textMuted as string),
               includeFontPadding: false,
               opacity: isDesktopWeb ? 0.76 : 1,
             }}
@@ -137,7 +156,9 @@ export function ProfileEditorForm({
               ...(isDesktopWeb ? BrandType.display : BrandType.title),
               fontSize: isDesktopWeb ? 32 : 20,
               lineHeight: isDesktopWeb ? 30 : undefined,
-              color: isDesktopWeb ? (palette.onPrimary as string) : (palette.text as string),
+              color: isDesktopWeb
+                ? (palette.onPrimary as string)
+                : (palette.text as string),
               includeFontPadding: false,
               letterSpacing: isDesktopWeb ? -0.8 : 0,
             }}
@@ -149,7 +170,9 @@ export function ProfileEditorForm({
               style={{
                 ...BrandType.bodyMedium,
                 fontSize: 13,
-                color: isDesktopWeb ? (palette.onPrimary as string) : (palette.textMuted as string),
+                color: isDesktopWeb
+                  ? (palette.onPrimary as string)
+                  : (palette.textMuted as string),
                 includeFontPadding: false,
                 opacity: isDesktopWeb ? 0.76 : 1,
               }}
@@ -158,20 +181,16 @@ export function ProfileEditorForm({
             </Text>
           ) : null}
         </View>
-        <KitButton
-          label={isChangingPhoto ? t("profile.editor.uploading") : t("profile.editor.photo")}
-          onPress={onChangePhoto}
-          variant="secondary"
-          size="sm"
-          disabled={isChangingPhoto}
-          fullWidth={false}
-          style={
-            isDesktopWeb
-              ? {
-                  backgroundColor: palette.surface as string,
-                }
-              : undefined
+        <ActionButton
+          label={
+            isChangingPhoto
+              ? t("profile.editor.uploading")
+              : t("profile.editor.photo")
           }
+          onPress={onChangePhoto}
+          disabled={isChangingPhoto}
+          palette={palette}
+          tone="secondary"
         />
       </View>
 
@@ -253,13 +272,28 @@ export function ProfileEditorForm({
               : t("profile.editor.addLinks")}
           </Text>
         </View>
-        <KitButton
-          label={showSocialFields ? t("profile.editor.hide") : t("common.edit")}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={
+            showSocialFields ? t("profile.editor.hide") : t("common.edit")
+          }
           onPress={() => setShowSocialFields((value) => !value)}
-          variant="ghost"
-          size="sm"
-          fullWidth={false}
-        />
+          style={({ pressed }) => ({
+            opacity: pressed ? 0.68 : 1,
+            paddingHorizontal: 6,
+            paddingVertical: 4,
+          })}
+        >
+          <Text
+            style={{
+              ...BrandType.bodyMedium,
+              color: palette.primary as string,
+              includeFontPadding: false,
+            }}
+          >
+            {showSocialFields ? t("profile.editor.hide") : t("common.edit")}
+          </Text>
+        </Pressable>
       </View>
 
       {showSocialFields ? (
@@ -293,7 +327,13 @@ export function ProfileEditorForm({
       }}
     >
       {isDesktopWeb ? (
-        <View style={{ flexDirection: "row", alignItems: "flex-start", gap: BrandSpacing.xl }}>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "flex-start",
+            gap: BrandSpacing.xl,
+          }}
+        >
           <View style={{ width: 380, gap: BrandSpacing.lg }}>
             {identityPanel}
             {basicsPanel}

--- a/src/components/profile/profile-hero-sheet.tsx
+++ b/src/components/profile/profile-hero-sheet.tsx
@@ -10,11 +10,15 @@ import Animated, {
 import { TopSheetSurface } from "@/components/layout/top-sheet-surface";
 import { ProfileIconButton } from "@/components/profile/profile-settings-sections";
 import type { ProfileSocialLinks } from "@/components/profile/profile-social-links";
-import { KitButton } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
 import { ProfileAvatar } from "@/components/ui/profile-avatar";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandSpacing, BrandType } from "@/constants/brand";
-import { isSportType, type SPORT_TYPES, toSportLabel } from "@/convex/constants";
+import {
+  isSportType,
+  type SPORT_TYPES,
+  toSportLabel,
+} from "@/convex/constants";
 import { useAppInsets } from "@/hooks/use-app-insets";
 
 const PROFILE_HERO_EXPANDED_CONTENT_HEIGHT = 204;
@@ -56,11 +60,16 @@ type ProfileHeroSheetProps = {
   sports: string[];
 };
 
-function getSportsLabel(sports: string[], t: ReturnType<typeof useTranslation>["t"]) {
+function getSportsLabel(
+  sports: string[],
+  t: ReturnType<typeof useTranslation>["t"],
+) {
   return sports.length === 0
     ? t("profile.settings.sports.none")
     : sports.length <= 2
-      ? sports.map((sport) => (isSportType(sport) ? toSportLabel(sport) : sport)).join(", ")
+      ? sports
+          .map((sport) => (isSportType(sport) ? toSportLabel(sport) : sport))
+          .join(", ")
       : `${isSportType(sports[0] ?? "") ? toSportLabel(sports[0] as (typeof SPORT_TYPES)[number]) : sports[0]} +${String(
           sports.length - 1,
         )}`;
@@ -99,7 +108,8 @@ export function ProfileHeroSheet({
   const activeSocialCount = Object.values(socialLinks ?? {}).filter((value) =>
     Boolean(value?.trim()),
   ).length;
-  const resolvedPrimaryActionLabel = primaryActionLabel ?? t("profile.actions.edit");
+  const resolvedPrimaryActionLabel =
+    primaryActionLabel ?? t("profile.actions.edit");
   const sportsLabel = getSportsLabel(sports, t);
   const summaryLabel = getProfileSummary(bio, activeSocialCount, t);
 
@@ -153,11 +163,21 @@ export function ProfileHeroSheet({
   const expandedDetailsStyle = useAnimatedStyle(() => ({
     opacity: interpolate(scrollY.value, [0, 80], [1, 0], Extrapolation.CLAMP),
     height: interpolate(scrollY.value, [0, 80], [88, 0], Extrapolation.CLAMP),
-    marginTop: interpolate(scrollY.value, [0, 80], [14, 0], Extrapolation.CLAMP),
+    marginTop: interpolate(
+      scrollY.value,
+      [0, 80],
+      [14, 0],
+      Extrapolation.CLAMP,
+    ),
   }));
 
   const animatedSheetStyle = useAnimatedStyle(() => {
-    const pullStretch = interpolate(scrollY.value, [-120, 0], [84, 0], Extrapolation.CLAMP);
+    const pullStretch = interpolate(
+      scrollY.value,
+      [-120, 0],
+      [84, 0],
+      Extrapolation.CLAMP,
+    );
     const collapsedBase = interpolate(
       scrollY.value,
       [0, PROFILE_HERO_COLLAPSE_END],
@@ -201,9 +221,17 @@ export function ProfileHeroSheet({
           paddingHorizontal: BrandSpacing.xl,
         }}
       >
-        <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 14 }}>
+        <View
+          style={{ flexDirection: "row", alignItems: "flex-start", gap: 14 }}
+        >
           <View
-            style={{ flexDirection: "row", alignItems: "center", gap: 14, flex: 1, minWidth: 0 }}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 14,
+              flex: 1,
+              minWidth: 0,
+            }}
           >
             <View style={{ borderRadius: 24 }}>
               <Animated.View style={profileAvatarStyle}>
@@ -217,7 +245,9 @@ export function ProfileHeroSheet({
               </Animated.View>
             </View>
 
-            <Animated.View style={[{ flex: 1, gap: 4, minWidth: 0 }, identityBlockStyle]}>
+            <Animated.View
+              style={[{ flex: 1, gap: 4, minWidth: 0 }, identityBlockStyle]}
+            >
               <Text
                 style={{
                   ...BrandType.micro,
@@ -447,22 +477,22 @@ export function ProfileDesktopHeroPanel({
 
       <View style={{ flexDirection: "row", gap: 10 }}>
         <View style={{ flex: 1 }}>
-          <KitButton
+          <ActionButton
             label={primaryAction.label}
             onPress={primaryAction.onPress}
-            variant="secondary"
-            size="sm"
-            icon="pencil"
+            palette={palette}
+            tone="secondary"
+            fullWidth
           />
         </View>
         {secondaryAction ? (
           <View style={{ flex: 1 }}>
-            <KitButton
+            <ActionButton
               label={secondaryAction.label}
               onPress={secondaryAction.onPress}
-              variant="secondary"
-              size="sm"
-              icon={secondaryAction.icon ?? "sparkles"}
+              palette={palette}
+              tone="secondary"
+              fullWidth
             />
           </View>
         ) : null}

--- a/src/components/profile/profile-readiness-banner.tsx
+++ b/src/components/profile/profile-readiness-banner.tsx
@@ -1,6 +1,7 @@
 import { Text, View } from "react-native";
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import { KitButton, KitSurface } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
+import { KitSurface } from "@/components/ui/kit";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandRadius, BrandType } from "@/constants/brand";
 
@@ -33,7 +34,9 @@ export function ProfileReadinessBanner({
           gap: 16,
         }}
       >
-        <View style={{ flexDirection: "row", alignItems: "flex-start", gap: 16 }}>
+        <View
+          style={{ flexDirection: "row", alignItems: "flex-start", gap: 16 }}
+        >
           <View
             style={{
               width: 44,
@@ -47,7 +50,11 @@ export function ProfileReadinessBanner({
             }}
           >
             <IconSymbol
-              name={primaryAction ? "exclamationmark.circle.fill" : "checkmark.seal.fill"}
+              name={
+                primaryAction
+                  ? "exclamationmark.circle.fill"
+                  : "checkmark.seal.fill"
+              }
               size={22}
               color={primaryAction ? palette.warning : palette.success}
             />
@@ -56,17 +63,22 @@ export function ProfileReadinessBanner({
             <Text style={{ ...BrandType.title, color: palette.text as string }}>
               {statusLabel}
             </Text>
-            <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+            <Text
+              style={{
+                ...BrandType.caption,
+                color: palette.textMuted as string,
+              }}
+            >
               {subtitleLabel}
             </Text>
           </View>
         </View>
         {primaryAction ? (
-          <KitButton
+          <ActionButton
             label={primaryAction.label}
             onPress={primaryAction.onPress}
-            size="sm"
-            style={{ width: "100%" }}
+            palette={palette}
+            fullWidth
           />
         ) : null}
       </KitSurface>

--- a/src/components/profile/profile-readiness-strip.tsx
+++ b/src/components/profile/profile-readiness-strip.tsx
@@ -1,8 +1,7 @@
-import { Text, useWindowDimensions, View } from "react-native";
+import { Pressable, Text, useWindowDimensions, View } from "react-native";
 
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { type BrandPalette, BrandRadius, BrandType } from "@/constants/brand";
-import { KitPressable } from "../ui/kit";
 
 type ReadinessItem = {
   label: string;
@@ -22,7 +21,8 @@ export function ProfileReadinessStrip({
   columns?: 1 | 2 | 4;
 }) {
   const { width } = useWindowDimensions();
-  const resolvedColumns = columns ?? (process.env.EXPO_OS === "web" && width >= 1180 ? 4 : 2);
+  const resolvedColumns =
+    columns ?? (process.env.EXPO_OS === "web" && width >= 1180 ? 4 : 2);
   const horizontalPadding = 48;
   const totalGap = resolvedColumns === 1 ? 0 : 10 * (resolvedColumns - 1);
   const tileWidth = Math.max(
@@ -84,7 +84,11 @@ export function ProfileReadinessStrip({
                     justifyContent: "center",
                   }}
                 >
-                  <IconSymbol name="arrow.up.right" size={14} color={palette.primary} />
+                  <IconSymbol
+                    name="arrow.up.right"
+                    size={14}
+                    color={palette.primary}
+                  />
                 </View>
               ) : null}
             </View>
@@ -121,15 +125,17 @@ export function ProfileReadinessStrip({
         }
 
         return (
-          <KitPressable
+          <Pressable
             key={item.label}
             accessibilityRole="button"
             accessibilityLabel={`${item.label}. ${item.value}`}
             onPress={item.onPress}
-            style={({ pressed }) => [{ width: tileWidth, opacity: pressed ? 0.84 : 1 }]}
+            style={({ pressed }) => [
+              { width: tileWidth, opacity: pressed ? 0.84 : 1 },
+            ]}
           >
             {content}
-          </KitPressable>
+          </Pressable>
         );
       })}
     </View>

--- a/src/components/profile/profile-settings-sections.tsx
+++ b/src/components/profile/profile-settings-sections.tsx
@@ -1,9 +1,14 @@
 import type { ComponentProps, ReactNode } from "react";
-import { Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import { KitPressable, KitSurface } from "@/components/ui/kit";
-import { type BrandPalette, BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
+import { KitSurface } from "@/components/ui/kit";
+import {
+  type BrandPalette,
+  BrandRadius,
+  BrandSpacing,
+  BrandType,
+} from "@/constants/brand";
 
 type ProfileSymbolName = ComponentProps<typeof IconSymbol>["name"];
 
@@ -30,7 +35,13 @@ export function ProfileSectionHeader({
       }}
     >
       <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-        {icon ? <IconSymbol name={icon} size={14} color={palette.textMuted as string} /> : null}
+        {icon ? (
+          <IconSymbol
+            name={icon}
+            size={14}
+            color={palette.textMuted as string}
+          />
+        ) : null}
         <Text
           style={{
             ...BrandType.micro,
@@ -101,11 +112,14 @@ export function ProfileIconButton({
   tone?: "neutral" | "accent";
 }) {
   const backgroundColor =
-    tone === "accent" ? (palette.primarySubtle as string) : (palette.surface as string);
-  const iconColor = tone === "accent" ? (palette.primary as string) : (palette.text as string);
+    tone === "accent"
+      ? (palette.primarySubtle as string)
+      : (palette.surface as string);
+  const iconColor =
+    tone === "accent" ? (palette.primary as string) : (palette.text as string);
 
   return (
-    <KitPressable
+    <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
@@ -125,7 +139,7 @@ export function ProfileIconButton({
       ]}
     >
       <IconSymbol name={icon} size={18} color={iconColor} />
-    </KitPressable>
+    </Pressable>
   );
 }
 
@@ -150,13 +164,22 @@ export function ProfileSettingRow({
   tone?: "default" | "danger";
   showDivider?: boolean;
 }) {
-  const titleColor = tone === "danger" ? (palette.danger as string) : (palette.text as string);
+  const titleColor =
+    tone === "danger" ? (palette.danger as string) : (palette.text as string);
   const secondaryColor =
-    tone === "danger" ? (palette.danger as string) : (palette.textMuted as string);
+    tone === "danger"
+      ? (palette.danger as string)
+      : (palette.textMuted as string);
   const iconBackground =
-    tone === "danger" ? (palette.dangerSubtle as string) : (palette.surfaceAlt as string);
-  const iconColor = tone === "danger" ? (palette.danger as string) : (palette.primary as string);
-  const borderColor = tone === "danger" ? "transparent" : (palette.border as string);
+    tone === "danger"
+      ? (palette.dangerSubtle as string)
+      : (palette.surfaceAlt as string);
+  const iconColor =
+    tone === "danger"
+      ? (palette.danger as string)
+      : (palette.primary as string);
+  const borderColor =
+    tone === "danger" ? "transparent" : (palette.border as string);
 
   const content = (
     <View
@@ -187,11 +210,19 @@ export function ProfileSettingRow({
       ) : null}
 
       <View style={{ flex: 1, gap: subtitle ? 3 : 0, minWidth: 0 }}>
-        <Text style={{ ...BrandType.bodyStrong, color: titleColor, letterSpacing: -0.1 }}>
+        <Text
+          style={{
+            ...BrandType.bodyStrong,
+            color: titleColor,
+            letterSpacing: -0.1,
+          }}
+        >
           {title}
         </Text>
         {subtitle ? (
-          <Text style={{ ...BrandType.caption, color: secondaryColor }}>{subtitle}</Text>
+          <Text style={{ ...BrandType.caption, color: secondaryColor }}>
+            {subtitle}
+          </Text>
         ) : null}
       </View>
 
@@ -217,7 +248,9 @@ export function ProfileSettingRow({
           </Text>
         ) : null}
         {accessory ??
-          (onPress ? <IconSymbol name="chevron.right" size={18} color={secondaryColor} /> : null)}
+          (onPress ? (
+            <IconSymbol name="chevron.right" size={18} color={secondaryColor} />
+          ) : null)}
       </View>
     </View>
   );
@@ -227,13 +260,13 @@ export function ProfileSettingRow({
   }
 
   return (
-    <KitPressable
+    <Pressable
       accessibilityRole="button"
       accessibilityLabel={[title, subtitle, value].filter(Boolean).join(". ")}
       onPress={onPress}
       style={({ pressed }) => [{ opacity: pressed ? 0.8 : 1 }]}
     >
       {content}
-    </KitPressable>
+    </Pressable>
   );
 }

--- a/src/components/profile/sports-multi-select.tsx
+++ b/src/components/profile/sports-multi-select.tsx
@@ -1,8 +1,7 @@
 import { useMemo, useState } from "react";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import { KitButton, KitPressable } from "@/components/ui/kit";
 import { NativeSearchField } from "@/components/ui/native-search-field";
 import type { BrandPalette } from "@/constants/brand";
 import { BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
@@ -35,7 +34,9 @@ export function SportsMultiSelect({
     if (!normalized) {
       return SPORT_TYPES;
     }
-    return SPORT_TYPES.filter((sport) => toSportLabel(sport).toLowerCase().includes(normalized));
+    return SPORT_TYPES.filter((sport) =>
+      toSportLabel(sport).toLowerCase().includes(normalized),
+    );
   }, [query]);
   const selectedSportsList = useMemo(
     () => SPORT_TYPES.filter((sport) => selectedSports.includes(sport)),
@@ -56,26 +57,46 @@ export function SportsMultiSelect({
         },
       ]}
     >
-      <KitPressable
+      <Pressable
         accessibilityRole="button"
         accessibilityLabel={title}
         onPress={() => setIsOpen((value) => !value)}
-        style={styles.header}
+        style={({ pressed }) => [
+          styles.header,
+          { opacity: pressed ? 0.82 : 1 },
+        ]}
       >
         <View style={styles.headerTextBlock}>
           <ThemedText type="defaultSemiBold">{title}</ThemedText>
           <ThemedText type="caption" style={{ color: palette.textMuted }}>
-            {selectedSports.length > 0 ? `${String(selectedSports.length)} selected` : emptyHint}
+            {selectedSports.length > 0
+              ? `${String(selectedSports.length)} selected`
+              : emptyHint}
           </ThemedText>
         </View>
-        <KitButton
-          label={isOpen ? "Done" : "Edit"}
-          onPress={() => setIsOpen((value) => !value)}
-          variant="ghost"
-          size="sm"
-          fullWidth={false}
-        />
-      </KitPressable>
+        <View
+          style={[
+            styles.headerBadge,
+            {
+              backgroundColor: isOpen
+                ? (palette.primarySubtle as string)
+                : (palette.surface as string),
+            },
+          ]}
+        >
+          <Text
+            style={{
+              ...BrandType.bodyMedium,
+              color: isOpen
+                ? (palette.primary as string)
+                : (palette.textMuted as string),
+              includeFontPadding: false,
+            }}
+          >
+            {isOpen ? "Done" : "Edit"}
+          </Text>
+        </View>
+      </Pressable>
 
       {isOpen ? (
         <View style={styles.panel}>
@@ -86,22 +107,43 @@ export function SportsMultiSelect({
           />
           {selectedSportsList.length > 0 ? (
             <View style={styles.section}>
-              <Text style={[styles.sectionLabel, { color: palette.textMuted as string }]}>
+              <Text
+                style={[
+                  styles.sectionLabel,
+                  { color: palette.textMuted as string },
+                ]}
+              >
                 Selected sports
               </Text>
               <View style={styles.resultsList}>
                 {selectedSportsList.map((sport) => (
-                  <KitPressable
+                  <Pressable
                     key={`selected-${sport}`}
                     accessibilityRole="button"
                     onPress={() => onToggleSport(sport)}
-                    style={[styles.resultRow, { backgroundColor: palette.primarySubtle as string }]}
+                    style={({ pressed }) => [
+                      styles.resultRow,
+                      {
+                        backgroundColor: palette.primarySubtle as string,
+                        opacity: pressed ? 0.82 : 1,
+                      },
+                    ]}
                   >
                     <View style={{ flex: 1, gap: 2 }}>
-                      <Text style={[styles.resultTitle, { color: palette.text as string }]}>
+                      <Text
+                        style={[
+                          styles.resultTitle,
+                          { color: palette.text as string },
+                        ]}
+                      >
                         {isSportType(sport) ? toSportLabel(sport) : sport}
                       </Text>
-                      <Text style={[styles.resultMeta, { color: palette.primary as string }]}>
+                      <Text
+                        style={[
+                          styles.resultMeta,
+                          { color: palette.primary as string },
+                        ]}
+                      >
                         Added to your teaching profile
                       </Text>
                     </View>
@@ -110,13 +152,18 @@ export function SportsMultiSelect({
                       size={18}
                       color={palette.primary as string}
                     />
-                  </KitPressable>
+                  </Pressable>
                 ))}
               </View>
             </View>
           ) : null}
           <View style={styles.section}>
-            <Text style={[styles.sectionLabel, { color: palette.textMuted as string }]}>
+            <Text
+              style={[
+                styles.sectionLabel,
+                { color: palette.textMuted as string },
+              ]}
+            >
               {query.trim().length > 0 ? "Matching sports" : "All sports"}
             </Text>
             <ScrollView
@@ -127,13 +174,24 @@ export function SportsMultiSelect({
             >
               {availableSportsList.length > 0 ? (
                 availableSportsList.map((sport) => (
-                  <KitPressable
+                  <Pressable
                     key={sport}
                     accessibilityRole="button"
                     onPress={() => onToggleSport(sport)}
-                    style={[styles.resultRow, { backgroundColor: palette.surface as string }]}
+                    style={({ pressed }) => [
+                      styles.resultRow,
+                      {
+                        backgroundColor: palette.surface as string,
+                        opacity: pressed ? 0.82 : 1,
+                      },
+                    ]}
                   >
-                    <Text style={[styles.resultTitle, { color: palette.text as string }]}>
+                    <Text
+                      style={[
+                        styles.resultTitle,
+                        { color: palette.text as string },
+                      ]}
+                    >
                       {toSportLabel(sport)}
                     </Text>
                     <IconSymbol
@@ -141,7 +199,7 @@ export function SportsMultiSelect({
                       size={18}
                       color={palette.textMuted as string}
                     />
-                  </KitPressable>
+                  </Pressable>
                 ))
               ) : (
                 <View
@@ -153,10 +211,20 @@ export function SportsMultiSelect({
                     },
                   ]}
                 >
-                  <Text style={[styles.resultTitle, { color: palette.text as string }]}>
+                  <Text
+                    style={[
+                      styles.resultTitle,
+                      { color: palette.text as string },
+                    ]}
+                  >
                     No matching sports
                   </Text>
-                  <Text style={[styles.resultMeta, { color: palette.textMuted as string }]}>
+                  <Text
+                    style={[
+                      styles.resultMeta,
+                      { color: palette.textMuted as string },
+                    ]}
+                  >
                     Try a different sport name.
                   </Text>
                 </View>
@@ -187,6 +255,12 @@ const styles = StyleSheet.create({
   headerTextBlock: {
     flex: 1,
     gap: 2,
+  },
+  headerBadge: {
+    borderRadius: 999,
+    borderCurve: "continuous",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
   },
   panel: {
     paddingHorizontal: 14,


### PR DESCRIPTION
## Summary
- remove kit action wrappers from reusable profile surfaces and editor controls
- simplify sports selection and profile hero/editor actions with plain pressables and ActionButton
- update the brutal audit execution log for the profile slice

## Verification
- bun run typecheck
- confirmed no KitButton or KitPressable references remain in the touched profile components