### PR TITLE
UI Cut 07: simplify profile route form actions

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -520,6 +520,12 @@ Replace with consequence and momentum:
 - simplified profile editor, readiness, and sports-selection controls without changing the route structure yet
 - kept the profile cleanup focused on shared components so later route cuts can delete more safely
 
+### Slice 07
+
+- removed kit button usage from the remaining profile route forms for sports, location, and calendar settings
+- kept those routes structurally intact while simplifying their action layer
+- finished the profile-form cleanup before moving to heavier calendar, map, and payments screens
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/calendar-settings.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/calendar-settings.tsx
@@ -8,8 +8,8 @@ import { Alert, Platform, StyleSheet, View } from "react-native";
 
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
+import { ActionButton } from "@/components/ui/action-button";
 import {
-  KitButton,
   KitList,
   KitListItem,
   KitSegmentedToggle,
@@ -29,7 +29,11 @@ const CALENDAR_PROVIDER_KEYS = {
 
 type CalendarProvider = keyof typeof CALENDAR_PROVIDER_KEYS;
 
-const GOOGLE_SCOPES = ["https://www.googleapis.com/auth/calendar.events", "openid", "email"];
+const GOOGLE_SCOPES = [
+  "https://www.googleapis.com/auth/calendar.events",
+  "openid",
+  "email",
+];
 
 const GOOGLE_DISCOVERY: AuthSession.DiscoveryDocument = {
   authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -37,7 +41,8 @@ const GOOGLE_DISCOVERY: AuthSession.DiscoveryDocument = {
   revocationEndpoint: "https://oauth2.googleapis.com/revoke",
 };
 
-const calendarApi = (api as unknown as { calendar: Record<string, unknown> }).calendar as {
+const calendarApi = (api as unknown as { calendar: Record<string, unknown> })
+  .calendar as {
   getMyGoogleCalendarStatus: unknown;
   disconnectGoogleCalendar: unknown;
   connectGoogleCalendarWithCode: unknown;
@@ -83,16 +88,20 @@ export default function CalendarSettingsScreen() {
   ) as GoogleCalendarStatus | undefined;
 
   const saveSettings = useMutation(api.users.updateMyInstructorSettings);
-  const disconnectGoogleCalendar = useAction(calendarApi.disconnectGoogleCalendar as any) as (
-    args: Record<string, never>,
-  ) => Promise<DisconnectGoogleCalendarResult>;
-  const exchangeGoogleCode = useAction(calendarApi.connectGoogleCalendarWithCode as any) as (args: {
+  const disconnectGoogleCalendar = useAction(
+    calendarApi.disconnectGoogleCalendar as any,
+  ) as (args: Record<string, never>) => Promise<DisconnectGoogleCalendarResult>;
+  const exchangeGoogleCode = useAction(
+    calendarApi.connectGoogleCalendarWithCode as any,
+  ) as (args: {
     code: string;
     codeVerifier: string;
     redirectUri: string;
     clientId: string;
   }) => Promise<unknown>;
-  const syncGoogleCalendar = useAction(calendarApi.syncMyGoogleCalendarEvents as any) as (args: {
+  const syncGoogleCalendar = useAction(
+    calendarApi.syncMyGoogleCalendarEvents as any,
+  ) as (args: {
     startTime?: number;
     endTime?: number;
     limit?: number;
@@ -109,7 +118,10 @@ export default function CalendarSettingsScreen() {
   const googleClientId = resolveGoogleClientId();
   const redirectUri =
     process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_REDIRECT_URL ??
-    AuthSession.makeRedirectUri({ scheme: "queue", path: "oauth/google-calendar" });
+    AuthSession.makeRedirectUri({
+      scheme: "queue",
+      path: "oauth/google-calendar",
+    });
 
   const [googleRequest, , promptGoogleAuth] = AuthSession.useAuthRequest(
     {
@@ -129,7 +141,9 @@ export default function CalendarSettingsScreen() {
 
   useEffect(() => {
     if (instructorSettings && !seeded) {
-      setProvider((instructorSettings.calendarProvider as CalendarProvider) ?? "none");
+      setProvider(
+        (instructorSettings.calendarProvider as CalendarProvider) ?? "none",
+      );
       setSyncEnabled(instructorSettings.calendarSyncEnabled ?? false);
       setSeeded(true);
     }
@@ -289,7 +303,9 @@ export default function CalendarSettingsScreen() {
                 setProvider(next);
                 if (next === "none") setSyncEnabled(false);
               }}
-              options={(Object.keys(CALENDAR_PROVIDER_KEYS) as CalendarProvider[]).map((key) => ({
+              options={(
+                Object.keys(CALENDAR_PROVIDER_KEYS) as CalendarProvider[]
+              ).map((key) => ({
                 value: key,
                 label: t(CALENDAR_PROVIDER_KEYS[key]),
               }))}
@@ -303,7 +319,10 @@ export default function CalendarSettingsScreen() {
           <KitSwitchRow
             title={t("profile.settings.calendar.autoSync")}
             value={syncEnabled}
-            disabled={provider === "none" || (provider === "google" && !hasGoogleConnection)}
+            disabled={
+              provider === "none" ||
+              (provider === "google" && !hasGoogleConnection)
+            }
             onValueChange={setSyncEnabled}
             description={t("profile.settings.calendar.futureNote")}
           />
@@ -319,7 +338,9 @@ export default function CalendarSettingsScreen() {
             />
           ) : null}
           {provider === "apple" ? (
-            <KitListItem title={t("profile.settings.calendar.applePermissionNote")} />
+            <KitListItem
+              title={t("profile.settings.calendar.applePermissionNote")}
+            />
           ) : null}
           {provider === "google" && googleStatus?.lastError ? (
             <KitListItem title={googleStatus.lastError} />
@@ -334,11 +355,13 @@ export default function CalendarSettingsScreen() {
         </KitList>
       </View>
 
-      <View style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}>
+      <View
+        style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}
+      >
         {provider === "google" ? (
           <View style={{ gap: 10 }}>
             {!hasGoogleConnection ? (
-              <KitButton
+              <ActionButton
                 label={
                   isConnectingGoogle
                     ? t("profile.settings.actions.connecting")
@@ -347,11 +370,15 @@ export default function CalendarSettingsScreen() {
                 onPress={() => {
                   void onConnectGoogle();
                 }}
-                disabled={isConnectingGoogle || !googleClientId || !googleRequest}
+                disabled={
+                  isConnectingGoogle || !googleClientId || !googleRequest
+                }
+                palette={palette}
+                fullWidth
               />
             ) : (
               <>
-                <KitButton
+                <ActionButton
                   label={
                     isSyncingGoogle
                       ? t("profile.settings.actions.syncing")
@@ -361,34 +388,48 @@ export default function CalendarSettingsScreen() {
                     void onSyncGoogleNow();
                   }}
                   disabled={isSyncingGoogle}
+                  palette={palette}
+                  fullWidth
                 />
-                <KitButton
+                <ActionButton
                   label={
                     isDisconnectingGoogle
                       ? t("profile.settings.actions.disconnecting")
                       : t("profile.settings.calendar.actions.disconnectGoogle")
                   }
-                  variant="secondary"
                   onPress={() => {
                     void onDisconnectGoogle();
                   }}
                   disabled={isDisconnectingGoogle}
+                  palette={palette}
+                  tone="secondary"
+                  fullWidth
                 />
               </>
             )}
           </View>
         ) : null}
 
-        <KitButton
+        <ActionButton
           label={
-            isSaving ? t("profile.settings.actions.saving") : t("profile.settings.actions.save")
+            isSaving
+              ? t("profile.settings.actions.saving")
+              : t("profile.settings.actions.save")
           }
           onPress={() => {
             void onSave();
           }}
           disabled={isSaving || !hasChanges}
+          palette={palette}
+          fullWidth
         />
-        <KitButton label={t("common.cancel")} variant="secondary" onPress={() => router.back()} />
+        <ActionButton
+          label={t("common.cancel")}
+          onPress={() => router.back()}
+          palette={palette}
+          tone="secondary"
+          fullWidth
+        />
       </View>
     </TabScreenScrollView>
   );

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/location.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/location.tsx
@@ -6,8 +6,9 @@ import { StyleSheet, View } from "react-native";
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
 import { ThemedText } from "@/components/themed-text";
+import { ActionButton } from "@/components/ui/action-button";
 import { AddressAutocomplete } from "@/components/ui/address-autocomplete";
-import { KitButton, KitList, KitListItem, KitSwitchRow } from "@/components/ui/kit";
+import { KitList, KitListItem, KitSwitchRow } from "@/components/ui/kit";
 import { BrandSpacing } from "@/constants/brand";
 import { useUser } from "@/contexts/user-context";
 import { api } from "@/convex/_generated/api";
@@ -16,12 +17,19 @@ import { useLocationResolution } from "@/hooks/use-location-resolution";
 import { getLocationResolveErrorMessage } from "@/lib/location-error-message";
 import type { ResolvedLocation } from "@/lib/location-zone";
 
-let zoneLabelByIdPromise: Promise<Map<string, { en: string; he: string }>> | null = null;
+let zoneLabelByIdPromise: Promise<
+  Map<string, { en: string; he: string }>
+> | null = null;
 
-async function getZoneLabelById(zoneId: string, language: "en" | "he"): Promise<string> {
+async function getZoneLabelById(
+  zoneId: string,
+  language: "en" | "he",
+): Promise<string> {
   if (!zoneLabelByIdPromise) {
     zoneLabelByIdPromise = import("@/constants/zones").then((module) => {
-      return new Map(module.ZONE_OPTIONS.map((zone) => [zone.id, zone.label] as const));
+      return new Map(
+        module.ZONE_OPTIONS.map((zone) => [zone.id, zone.label] as const),
+      );
     });
   }
 
@@ -46,13 +54,16 @@ export default function LocationScreen() {
   const [latitude, setLatitude] = useState<number>();
   const [longitude, setLongitude] = useState<number>();
   const [detectedZone, setDetectedZone] = useState<string | null>(null);
-  const [detectedZoneLabel, setDetectedZoneLabel] = useState<string | null>(null);
+  const [detectedZoneLabel, setDetectedZoneLabel] = useState<string | null>(
+    null,
+  );
   const [includeDetectedZone, setIncludeDetectedZone] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [seeded, setSeeded] = useState(false);
   const screenStyle = useMemo(
-    () => StyleSheet.flatten([styles.screen, { backgroundColor: palette.appBg }]),
+    () =>
+      StyleSheet.flatten([styles.screen, { backgroundColor: palette.appBg }]),
     [palette.appBg],
   );
 
@@ -137,7 +148,11 @@ export default function LocationScreen() {
       });
       router.back();
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : t("profile.settings.errors.saveFailed"));
+      setErrorMessage(
+        err instanceof Error
+          ? err.message
+          : t("profile.settings.errors.saveFailed"),
+      );
     } finally {
       setIsSaving(false);
     }
@@ -187,17 +202,19 @@ export default function LocationScreen() {
               surfaceColor={palette.surface}
               mutedTextColor={palette.textMuted}
             />
-            <KitButton
+            <ActionButton
               label={
                 locationResolver.isResolving
                   ? t("profile.settings.location.resolvingGps")
                   : t("profile.settings.location.useGps")
               }
-              variant="secondary"
               onPress={() => {
                 void resolveByGps();
               }}
               disabled={locationResolver.isResolving}
+              palette={palette}
+              tone="secondary"
+              fullWidth
             />
           </View>
         </KitListItem>
@@ -210,7 +227,9 @@ export default function LocationScreen() {
             styles.locationBadge,
             {
               borderColor: detectedZone ? palette.primary : palette.border,
-              backgroundColor: detectedZone ? palette.primarySubtle : palette.appBg,
+              backgroundColor: detectedZone
+                ? palette.primarySubtle
+                : palette.appBg,
             },
           ]}
         >
@@ -244,22 +263,36 @@ export default function LocationScreen() {
       {/* Error */}
       {errorMessage ? (
         <View style={{ paddingHorizontal: 16, paddingTop: 12 }}>
-          <ThemedText style={{ color: palette.danger }}>{errorMessage}</ThemedText>
+          <ThemedText style={{ color: palette.danger }}>
+            {errorMessage}
+          </ThemedText>
         </View>
       ) : null}
 
       {/* Actions */}
-      <View style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}>
-        <KitButton
+      <View
+        style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}
+      >
+        <ActionButton
           label={
-            isSaving ? t("profile.settings.actions.saving") : t("profile.settings.actions.save")
+            isSaving
+              ? t("profile.settings.actions.saving")
+              : t("profile.settings.actions.save")
           }
           onPress={() => {
             void onSave();
           }}
           disabled={isSaving}
+          palette={palette}
+          fullWidth
         />
-        <KitButton label={t("common.cancel")} variant="secondary" onPress={() => router.back()} />
+        <ActionButton
+          label={t("common.cancel")}
+          onPress={() => router.back()}
+          palette={palette}
+          tone="secondary"
+          fullWidth
+        />
       </View>
     </TabScreenScrollView>
   );

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/sports.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/sports.tsx
@@ -8,7 +8,7 @@ import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view"
 import { LoadingScreen } from "@/components/loading-screen";
 import { SportsMultiSelect } from "@/components/profile/sports-multi-select";
 import { ThemedText } from "@/components/themed-text";
-import { KitButton } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
 import { BrandSpacing } from "@/constants/brand";
 import { useUser } from "@/contexts/user-context";
 import { api } from "@/convex/_generated/api";
@@ -88,7 +88,9 @@ export default function SportsScreen() {
       router.back();
     } catch (error) {
       setErrorMessage(
-        error instanceof Error ? error.message : t("profile.settings.errors.saveFailed"),
+        error instanceof Error
+          ? error.message
+          : t("profile.settings.errors.saveFailed"),
       );
     } finally {
       setIsSaving(false);
@@ -99,7 +101,11 @@ export default function SportsScreen() {
     <View style={[styles.screen, { backgroundColor: palette.appBg }]}>
       <TabScreenScrollView
         routeKey="instructor/profile"
-        contentContainerStyle={{ padding: 16, paddingBottom: hasChanges ? 120 : 100, gap: 12 }}
+        contentContainerStyle={{
+          padding: 16,
+          paddingBottom: hasChanges ? 120 : 100,
+          gap: 12,
+        }}
       >
         <ThemedText type="caption" style={{ color: palette.textMuted }}>
           {sports.length > 0
@@ -126,14 +132,18 @@ export default function SportsScreen() {
       {/* Save FAB */}
       {hasChanges ? (
         <View style={[styles.saveFabArea, { bottom: overlayBottom }]}>
-          <KitButton
+          <ActionButton
             label={
-              isSaving ? t("profile.settings.actions.saving") : t("profile.settings.actions.save")
+              isSaving
+                ? t("profile.settings.actions.saving")
+                : t("profile.settings.actions.save")
             }
             onPress={() => {
               void onSave();
             }}
             disabled={isSaving}
+            palette={palette}
+            fullWidth
           />
         </View>
       ) : null}

--- a/src/app/(app)/(studio-tabs)/studio/profile/calendar-settings.tsx
+++ b/src/app/(app)/(studio-tabs)/studio/profile/calendar-settings.tsx
@@ -8,8 +8,8 @@ import { Alert, Platform, StyleSheet, View } from "react-native";
 
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
+import { ActionButton } from "@/components/ui/action-button";
 import {
-  KitButton,
   KitList,
   KitListItem,
   KitSegmentedToggle,
@@ -29,7 +29,11 @@ const CALENDAR_PROVIDER_KEYS = {
 
 type CalendarProvider = keyof typeof CALENDAR_PROVIDER_KEYS;
 
-const GOOGLE_SCOPES = ["https://www.googleapis.com/auth/calendar.events", "openid", "email"];
+const GOOGLE_SCOPES = [
+  "https://www.googleapis.com/auth/calendar.events",
+  "openid",
+  "email",
+];
 
 const GOOGLE_DISCOVERY: AuthSession.DiscoveryDocument = {
   authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
@@ -37,7 +41,8 @@ const GOOGLE_DISCOVERY: AuthSession.DiscoveryDocument = {
   revocationEndpoint: "https://oauth2.googleapis.com/revoke",
 };
 
-const calendarApi = (api as unknown as { calendar: Record<string, unknown> }).calendar as {
+const calendarApi = (api as unknown as { calendar: Record<string, unknown> })
+  .calendar as {
   getMyGoogleCalendarStatus: unknown;
   disconnectGoogleCalendar: unknown;
   connectGoogleCalendarWithCode: unknown;
@@ -89,16 +94,20 @@ export default function StudioCalendarSettingsScreen() {
   ) as GoogleCalendarStatus | undefined;
 
   const saveSettings = useMutation(api.users.updateMyStudioCalendarSettings);
-  const disconnectGoogleCalendar = useAction(calendarApi.disconnectGoogleCalendar as any) as (
-    args: Record<string, never>,
-  ) => Promise<DisconnectGoogleCalendarResult>;
-  const exchangeGoogleCode = useAction(calendarApi.connectGoogleCalendarWithCode as any) as (args: {
+  const disconnectGoogleCalendar = useAction(
+    calendarApi.disconnectGoogleCalendar as any,
+  ) as (args: Record<string, never>) => Promise<DisconnectGoogleCalendarResult>;
+  const exchangeGoogleCode = useAction(
+    calendarApi.connectGoogleCalendarWithCode as any,
+  ) as (args: {
     code: string;
     codeVerifier: string;
     redirectUri: string;
     clientId: string;
   }) => Promise<unknown>;
-  const syncGoogleCalendar = useAction(calendarApi.syncMyGoogleCalendarEvents as any) as (args: {
+  const syncGoogleCalendar = useAction(
+    calendarApi.syncMyGoogleCalendarEvents as any,
+  ) as (args: {
     startTime?: number;
     endTime?: number;
     limit?: number;
@@ -115,7 +124,10 @@ export default function StudioCalendarSettingsScreen() {
   const googleClientId = resolveGoogleClientId();
   const redirectUri =
     process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_REDIRECT_URL ??
-    AuthSession.makeRedirectUri({ scheme: "queue", path: "oauth/google-calendar" });
+    AuthSession.makeRedirectUri({
+      scheme: "queue",
+      path: "oauth/google-calendar",
+    });
 
   const [googleRequest, , promptGoogleAuth] = AuthSession.useAuthRequest(
     {
@@ -267,7 +279,10 @@ export default function StudioCalendarSettingsScreen() {
     : null;
 
   return (
-    <TabScreenScrollView routeKey="studio/profile" style={[styles.screen, { backgroundColor: palette.appBg }]}>
+    <TabScreenScrollView
+      routeKey="studio/profile"
+      style={[styles.screen, { backgroundColor: palette.appBg }]}
+    >
       <KitList inset>
         <KitListItem title={t("profile.settings.calendar.provider.none")}>
           <View style={{ marginTop: 8 }}>
@@ -277,7 +292,9 @@ export default function StudioCalendarSettingsScreen() {
                 setProvider(next);
                 if (next === "none") setSyncEnabled(false);
               }}
-              options={(Object.keys(CALENDAR_PROVIDER_KEYS) as CalendarProvider[]).map((key) => ({
+              options={(
+                Object.keys(CALENDAR_PROVIDER_KEYS) as CalendarProvider[]
+              ).map((key) => ({
                 value: key,
                 label: t(CALENDAR_PROVIDER_KEYS[key]),
               }))}
@@ -291,7 +308,10 @@ export default function StudioCalendarSettingsScreen() {
           <KitSwitchRow
             title={t("profile.settings.calendar.autoSync")}
             value={syncEnabled}
-            disabled={provider === "none" || (provider === "google" && !hasGoogleConnection)}
+            disabled={
+              provider === "none" ||
+              (provider === "google" && !hasGoogleConnection)
+            }
             onValueChange={setSyncEnabled}
             description={t("profile.settings.calendar.futureNote")}
           />
@@ -307,7 +327,9 @@ export default function StudioCalendarSettingsScreen() {
             />
           ) : null}
           {provider === "apple" ? (
-            <KitListItem title={t("profile.settings.calendar.applePermissionNote")} />
+            <KitListItem
+              title={t("profile.settings.calendar.applePermissionNote")}
+            />
           ) : null}
           {provider === "google" && googleStatus?.lastError ? (
             <KitListItem title={googleStatus.lastError} />
@@ -322,11 +344,13 @@ export default function StudioCalendarSettingsScreen() {
         </KitList>
       </View>
 
-      <View style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}>
+      <View
+        style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}
+      >
         {provider === "google" ? (
           <View style={{ gap: 10 }}>
             {!hasGoogleConnection ? (
-              <KitButton
+              <ActionButton
                 label={
                   isConnectingGoogle
                     ? t("profile.settings.actions.connecting")
@@ -335,11 +359,15 @@ export default function StudioCalendarSettingsScreen() {
                 onPress={() => {
                   void onConnectGoogle();
                 }}
-                disabled={isConnectingGoogle || !googleClientId || !googleRequest}
+                disabled={
+                  isConnectingGoogle || !googleClientId || !googleRequest
+                }
+                palette={palette}
+                fullWidth
               />
             ) : (
               <>
-                <KitButton
+                <ActionButton
                   label={
                     isSyncingGoogle
                       ? t("profile.settings.actions.syncing")
@@ -349,34 +377,48 @@ export default function StudioCalendarSettingsScreen() {
                     void onSyncGoogleNow();
                   }}
                   disabled={isSyncingGoogle}
+                  palette={palette}
+                  fullWidth
                 />
-                <KitButton
+                <ActionButton
                   label={
                     isDisconnectingGoogle
                       ? t("profile.settings.actions.disconnecting")
                       : t("profile.settings.calendar.actions.disconnectGoogle")
                   }
-                  variant="secondary"
                   onPress={() => {
                     void onDisconnectGoogle();
                   }}
                   disabled={isDisconnectingGoogle}
+                  palette={palette}
+                  tone="secondary"
+                  fullWidth
                 />
               </>
             )}
           </View>
         ) : null}
 
-        <KitButton
+        <ActionButton
           label={
-            isSaving ? t("profile.settings.actions.saving") : t("profile.settings.actions.save")
+            isSaving
+              ? t("profile.settings.actions.saving")
+              : t("profile.settings.actions.save")
           }
           onPress={() => {
             void onSave();
           }}
           disabled={isSaving || !hasChanges}
+          palette={palette}
+          fullWidth
         />
-        <KitButton label={t("common.cancel")} variant="secondary" onPress={() => router.back()} />
+        <ActionButton
+          label={t("common.cancel")}
+          onPress={() => router.back()}
+          palette={palette}
+          tone="secondary"
+          fullWidth
+        />
       </View>
     </TabScreenScrollView>
   );


### PR DESCRIPTION
## Summary
- remove kit button usage from profile sports, location, and both calendar settings screens
- keep route structure stable while simplifying the action layer to ActionButton
- update the audit execution log for the route-form slice

## Verification
- bun run typecheck
- confirmed no KitButton references remain in the touched route files