### PR TITLE
UI Cut 08: simplify shared surface interactions

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -526,6 +526,12 @@ Replace with consequence and momentum:
 - kept those routes structurally intact while simplifying their action layer
 - finished the profile-form cleanup before moving to heavier calendar, map, and payments screens
 
+### Slice 08
+
+- removed kit action wrappers from medium shared surfaces including address autocomplete, payment activity rows, web tabs, map controls, and the performance hero selector
+- kept the slice tactical so the remaining work is concentrated in the largest screen files
+- reduced more interaction plumbing without expanding the abstraction surface
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/components/home/performance-hero-card.tsx
+++ b/src/components/home/performance-hero-card.tsx
@@ -1,12 +1,24 @@
 import { useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { type LayoutChangeEvent, PanResponder, Text, View } from "react-native";
+import {
+  type LayoutChangeEvent,
+  PanResponder,
+  Pressable,
+  Text,
+  View,
+} from "react-native";
 import Svg, { Defs, LinearGradient, Path, Stop } from "react-native-svg";
 import { useHomeDashboardLayout } from "@/components/home/home-dashboard-layout";
-import type { AxisTick, MetricMode, Timeframe } from "@/components/home/performance-chart-math";
-import { buildSplinePaths, getAdjacentTimeframe } from "@/components/home/performance-chart-math";
+import type {
+  AxisTick,
+  MetricMode,
+  Timeframe,
+} from "@/components/home/performance-chart-math";
+import {
+  buildSplinePaths,
+  getAdjacentTimeframe,
+} from "@/components/home/performance-chart-math";
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import { KitPressable } from "@/components/ui/kit";
 import { type BrandPalette, BrandRadius, BrandType } from "@/constants/brand";
 
 export type PerformanceTimeframeSeries = {
@@ -45,7 +57,10 @@ type AxisLabelEntry = {
   x: number;
 };
 
-const METRIC_ICONS: Record<MetricMode, "creditcard.fill" | "calendar.badge.clock"> = {
+const METRIC_ICONS: Record<
+  MetricMode,
+  "creditcard.fill" | "calendar.badge.clock"
+> = {
   earnings: "creditcard.fill",
   lessons: "calendar.badge.clock",
 };
@@ -72,10 +87,19 @@ export function PerformanceHeroCard({
   const gradientId = `hero-fill-${useId()}`;
 
   const currentSeries = seriesByTimeframe[timeframe];
-  const currentMetricOption = metricOptions.find((option) => option.value === metricMode);
-  const currentMetricLabel = currentMetricOption?.label ?? t(`home.performance.${metricMode}`);
+  const currentMetricOption = metricOptions.find(
+    (option) => option.value === metricMode,
+  );
+  const currentMetricLabel =
+    currentMetricOption?.label ?? t(`home.performance.${metricMode}`);
   const { linePath, areaPath, separators, pointXs, hasActivity } = useMemo(
-    () => buildSplinePaths(currentSeries.values, chartWidth, chartHeight, chartPadding),
+    () =>
+      buildSplinePaths(
+        currentSeries.values,
+        chartWidth,
+        chartHeight,
+        chartPadding,
+      ),
     [chartHeight, chartWidth, currentSeries.values],
   );
 
@@ -102,7 +126,8 @@ export function PerformanceHeroCard({
     () =>
       PanResponder.create({
         onMoveShouldSetPanResponder: (_evt, gestureState) =>
-          Math.abs(gestureState.dx) > 12 && Math.abs(gestureState.dx) > Math.abs(gestureState.dy),
+          Math.abs(gestureState.dx) > 12 &&
+          Math.abs(gestureState.dx) > Math.abs(gestureState.dy),
         onPanResponderRelease: (_evt, gestureState) => {
           const absDx = Math.abs(gestureState.dx);
           if (absDx >= 44) {
@@ -141,7 +166,14 @@ export function PerformanceHeroCard({
         }}
       >
         <View style={{ flex: 1, gap: 10 }}>
-          <View style={{ flexDirection: "row", alignItems: "center", flexWrap: "wrap", gap: 8 }}>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: 8,
+            }}
+          >
             <View
               style={{
                 flexDirection: "row",
@@ -191,7 +223,11 @@ export function PerformanceHeroCard({
             {totalLabel}
           </Text>
           <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-            <IconSymbol name="sparkles" size={14} color={palette.onPrimary as string} />
+            <IconSymbol
+              name="sparkles"
+              size={14}
+              color={palette.onPrimary as string}
+            />
             <Text
               style={{
                 ...BrandType.micro,
@@ -219,7 +255,7 @@ export function PerformanceHeroCard({
           {metricOptions.map((option) => {
             const selected = option.value === metricMode;
             return (
-              <KitPressable
+              <Pressable
                 key={option.value}
                 accessibilityRole="button"
                 accessibilityState={{ selected }}
@@ -227,9 +263,7 @@ export function PerformanceHeroCard({
                   metric: option.label,
                 })}
                 onPress={() => onSelectMetric(option.value)}
-                nativeFeedback={false}
-                pressStyle={{ opacity: 0.9, transform: [{ scale: 0.98 }] }}
-                style={{
+                style={({ pressed }) => ({
                   minHeight: 36,
                   minWidth: 82,
                   flex: layout.isWideWeb ? undefined : 1,
@@ -242,23 +276,31 @@ export function PerformanceHeroCard({
                   backgroundColor: selected
                     ? (palette.onPrimary as string)
                     : "rgba(255,255,255,0.08)",
-                }}
+                  opacity: pressed ? 0.9 : 1,
+                  transform: [{ scale: pressed ? 0.98 : 1 }],
+                })}
               >
                 <IconSymbol
                   name={METRIC_ICONS[option.value]}
                   size={14}
-                  color={selected ? (palette.primary as string) : (palette.onPrimary as string)}
+                  color={
+                    selected
+                      ? (palette.primary as string)
+                      : (palette.onPrimary as string)
+                  }
                 />
                 <Text
                   style={{
                     ...BrandType.micro,
-                    color: selected ? (palette.primary as string) : (palette.onPrimary as string),
+                    color: selected
+                      ? (palette.primary as string)
+                      : (palette.onPrimary as string),
                     opacity: selected ? 1 : 0.76,
                   }}
                 >
                   {option.label}
                 </Text>
-              </KitPressable>
+              </Pressable>
             );
           })}
         </View>
@@ -285,7 +327,10 @@ export function PerformanceHeroCard({
           paddingTop: 10,
         }}
       >
-        <View style={{ flex: 1 }} importantForAccessibility="no-hide-descendants">
+        <View
+          style={{ flex: 1 }}
+          importantForAccessibility="no-hide-descendants"
+        >
           {separators.map((x, idx) => (
             <View
               key={`separator-${String(idx)}`}
@@ -307,13 +352,28 @@ export function PerformanceHeroCard({
           >
             <Defs>
               <LinearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                <Stop offset="0%" stopColor={palette.onPrimary as string} stopOpacity={0.34} />
-                <Stop offset="100%" stopColor={palette.onPrimary as string} stopOpacity={0.04} />
+                <Stop
+                  offset="0%"
+                  stopColor={palette.onPrimary as string}
+                  stopOpacity={0.34}
+                />
+                <Stop
+                  offset="100%"
+                  stopColor={palette.onPrimary as string}
+                  stopOpacity={0.04}
+                />
               </LinearGradient>
             </Defs>
-            {hasActivity && areaPath ? <Path d={areaPath} fill={`url(#${gradientId})`} /> : null}
+            {hasActivity && areaPath ? (
+              <Path d={areaPath} fill={`url(#${gradientId})`} />
+            ) : null}
             {linePath ? (
-              <Path d={linePath} stroke={palette.onPrimary as string} strokeWidth={3} fill="none" />
+              <Path
+                d={linePath}
+                stroke={palette.onPrimary as string}
+                strokeWidth={3}
+                fill="none"
+              />
             ) : null}
           </Svg>
         </View>
@@ -351,17 +411,18 @@ export function PerformanceHeroCard({
           gap: 10,
         }}
       >
-        <View style={{ flexDirection: "row", gap: 8, flex: 1, flexWrap: "wrap" }}>
+        <View
+          style={{ flexDirection: "row", gap: 8, flex: 1, flexWrap: "wrap" }}
+        >
           {timeframeOptions.map((option) => {
             const selected = option.value === timeframe;
             return (
-              <KitPressable
+              <Pressable
                 key={option.value}
                 accessibilityRole="button"
                 accessibilityState={{ selected }}
                 onPress={() => onSelectTimeframe(option.value)}
-                nativeFeedback={false}
-                style={{
+                style={({ pressed }) => ({
                   minHeight: 34,
                   borderRadius: BrandRadius.pill,
                   alignItems: "center",
@@ -370,18 +431,21 @@ export function PerformanceHeroCard({
                   backgroundColor: selected
                     ? (palette.onPrimary as string)
                     : "rgba(255,255,255,0.12)",
-                }}
+                  opacity: pressed ? 0.9 : 1,
+                })}
               >
                 <Text
                   style={{
                     ...BrandType.micro,
-                    color: selected ? (palette.primary as string) : (palette.onPrimary as string),
+                    color: selected
+                      ? (palette.primary as string)
+                      : (palette.onPrimary as string),
                     opacity: selected ? 1 : 0.76,
                   }}
                 >
                   {option.label}
                 </Text>
-              </KitPressable>
+              </Pressable>
             );
           })}
         </View>

--- a/src/components/maps/queue-map.native.tsx
+++ b/src/components/maps/queue-map.native.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import {
   ActivityIndicator,
   InteractionManager,
+  Pressable,
   StyleSheet,
   View,
 } from "react-native";
@@ -29,8 +30,9 @@ import {
 } from "@/constants/zones-map";
 import { useBrand } from "@/hooks/use-brand";
 import { useThemePreference } from "@/hooks/use-theme-preference";
+import { ActionButton } from "../ui/action-button";
 import { IconSymbol } from "../ui/icon-symbol";
-import { KitButton, KitPressable, KitSurface } from "../ui/kit";
+import { KitSurface } from "../ui/kit";
 import type { QueueMapPin, QueueMapProps } from "./queue-map.types";
 
 type Expression = unknown;
@@ -522,23 +524,22 @@ export function QueueMap({
             <ThemedText type="meta" style={{ color: palette.textMuted }}>
               {mapErrorMessage ?? t("mapTab.native.unavailableBody")}
             </ThemedText>
-            <KitButton
+            <ActionButton
               label={t("tabsLayout.actions.retry")}
               onPress={handleRetry}
-              fullWidth={false}
-              variant="secondary"
+              palette={palette}
+              tone="secondary"
             />
           </KitSurface>
         </View>
       ) : null}
 
       {showGpsButton && onUseGps ? (
-        <KitPressable
+        <Pressable
           accessibilityRole="button"
           accessibilityLabel={t("mapTab.actions.useCurrentLocation")}
           onPress={onUseGps}
-          haptic="impact"
-          style={[
+          style={({ pressed }) => [
             styles.gps,
             {
               width: 58,
@@ -552,11 +553,12 @@ export function QueueMap({
               borderColor: palette.borderStrong as string,
               boxShadow: "0 16px 30px rgba(15, 23, 15, 0.14)",
               overflow: "hidden",
+              opacity: pressed ? 0.84 : 1,
             },
           ]}
         >
           <IconSymbol name="location.fill" size={20} color={palette.text} />
-        </KitPressable>
+        </Pressable>
       ) : null}
     </View>
   );

--- a/src/components/maps/queue-map.web.tsx
+++ b/src/components/maps/queue-map.web.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 
 import { AppSymbol } from "@/components/ui/app-symbol";
-import { KitPressable } from "@/components/ui/kit";
 import { BrandRadius, BrandType } from "@/constants/brand";
 import { ZONE_OPTIONS } from "@/constants/zones";
 import { useBrand } from "@/hooks/use-brand";
@@ -44,23 +43,30 @@ function getZone(zoneId: string) {
   return ZONE_OPTIONS.find((zone) => zone.id === zoneId);
 }
 
-function buildCoverageNodes(selectedZoneIds: string[], focusZoneId: string | null): CoverageNode[] {
+function buildCoverageNodes(
+  selectedZoneIds: string[],
+  focusZoneId: string | null,
+): CoverageNode[] {
   const selectedSet = new Set(selectedZoneIds);
   const orderedSelected = selectedZoneIds
     .map((zoneId) => getZone(zoneId))
     .filter((zone): zone is NonNullable<typeof zone> => Boolean(zone));
-  const focusIndex = orderedSelected.findIndex((zone) => zone.id === focusZoneId);
+  const focusIndex = orderedSelected.findIndex(
+    (zone) => zone.id === focusZoneId,
+  );
   if (focusIndex > 0) {
     const focusedZone = orderedSelected[focusIndex];
     if (focusedZone === undefined) return [];
     orderedSelected.splice(focusIndex, 1);
     orderedSelected.unshift(focusedZone);
   }
-  const previewZones = ZONE_OPTIONS.filter((zone) => !selectedSet.has(zone.id)).slice(
+  const previewZones = ZONE_OPTIONS.filter(
+    (zone) => !selectedSet.has(zone.id),
+  ).slice(0, Math.max(0, COVERAGE_SLOTS.length - orderedSelected.length));
+  const visibleZones = [...orderedSelected, ...previewZones].slice(
     0,
-    Math.max(0, COVERAGE_SLOTS.length - orderedSelected.length),
+    COVERAGE_SLOTS.length,
   );
-  const visibleZones = [...orderedSelected, ...previewZones].slice(0, COVERAGE_SLOTS.length);
 
   return visibleZones.reduce<CoverageNode[]>((nodes, zone, index) => {
     const slot = COVERAGE_SLOTS[index];
@@ -85,7 +91,10 @@ function buildCoverageNodes(selectedZoneIds: string[], focusZoneId: string | nul
 
 function getResponseLabel(
   seconds: number,
-  labels: Record<"instant" | "thirtySeconds" | "oneMinute" | "ninetySeconds", string>,
+  labels: Record<
+    "instant" | "thirtySeconds" | "oneMinute" | "ninetySeconds",
+    string
+  >,
 ) {
   if (seconds <= 0) return labels.instant;
   if (seconds <= 30) return labels.thirtySeconds;
@@ -96,7 +105,11 @@ function getResponseLabel(
 export function QueueMap(props: QueueMapProps) {
   const { t, i18n } = useTranslation();
   const palette = useBrand();
-  const zoneLanguage = (i18n.resolvedLanguage ?? "en").toLowerCase().startsWith("he") ? "he" : "en";
+  const zoneLanguage = (i18n.resolvedLanguage ?? "en")
+    .toLowerCase()
+    .startsWith("he")
+    ? "he"
+    : "en";
   const responseLabels = useMemo(
     () => ({
       instant: t("mapTab.web.instant"),
@@ -115,7 +128,9 @@ export function QueueMap(props: QueueMapProps) {
     () => (props.focusZoneId ? (getZone(props.focusZoneId) ?? null) : null),
     [props.focusZoneId],
   );
-  const selectedPreview = coverageNodes.filter((node) => node.selected).slice(0, 4);
+  const selectedPreview = coverageNodes
+    .filter((node) => node.selected)
+    .slice(0, 4);
 
   return (
     <View
@@ -185,7 +200,11 @@ export function QueueMap(props: QueueMapProps) {
                   backgroundColor: palette.primary as string,
                 }}
               >
-                <AppSymbol name="map.fill" size={24} tintColor={palette.onPrimary as string} />
+                <AppSymbol
+                  name="map.fill"
+                  size={24}
+                  tintColor={palette.onPrimary as string}
+                />
               </View>
             </View>
 
@@ -312,10 +331,19 @@ export function QueueMap(props: QueueMapProps) {
                     color: palette.text as string,
                   }}
                 >
-                  {focusedZone ? focusedZone.label[zoneLanguage] : t("mapTab.web.noFocusLocked")}
+                  {focusedZone
+                    ? focusedZone.label[zoneLanguage]
+                    : t("mapTab.web.noFocusLocked")}
                 </Text>
-                <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
-                  {focusedZone ? t("mapTab.web.focusHelp") : t("mapTab.web.focusEmpty")}
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  {focusedZone
+                    ? t("mapTab.web.focusHelp")
+                    : t("mapTab.web.focusEmpty")}
                 </Text>
               </View>
 
@@ -371,12 +399,12 @@ export function QueueMap(props: QueueMapProps) {
                   : (palette.textMuted as string);
 
               return (
-                <KitPressable
+                <Pressable
                   key={node.zoneId}
                   accessibilityRole={isEditable ? "button" : undefined}
                   disabled={!isEditable}
                   onPress={() => props.onPressZone?.(node.zoneId)}
-                  style={{
+                  style={({ pressed }) => ({
                     position: "absolute",
                     left: `${node.left}%` as `${number}%`,
                     top: `${node.top}%` as `${number}%`,
@@ -389,8 +417,12 @@ export function QueueMap(props: QueueMapProps) {
                     paddingVertical: 12,
                     justifyContent: "space-between",
                     transform: [{ rotate: `${String(node.rotate)}deg` }],
-                    opacity: node.selected || node.focused ? 1 : 0.92,
-                  }}
+                    opacity: pressed
+                      ? 0.84
+                      : node.selected || node.focused
+                        ? 1
+                        : 0.92,
+                  })}
                 >
                   <Text
                     numberOfLines={2}
@@ -424,7 +456,7 @@ export function QueueMap(props: QueueMapProps) {
                         : getResponseLabel(node.seconds, responseLabels)}
                     </Text>
                   </View>
-                </KitPressable>
+                </Pressable>
               );
             })}
           </View>
@@ -466,7 +498,9 @@ export function QueueMap(props: QueueMapProps) {
                   color: palette.onPrimary as string,
                 }}
               >
-                {props.onPressZone ? t("mapTab.web.interactive") : t("mapTab.web.preview")}
+                {props.onPressZone
+                  ? t("mapTab.web.interactive")
+                  : t("mapTab.web.preview")}
               </Text>
             </View>
 
@@ -493,7 +527,9 @@ export function QueueMap(props: QueueMapProps) {
               </Text>
 
               {selectedPreview.length > 0 ? (
-                <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                <View
+                  style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}
+                >
                   {selectedPreview.map((node) => (
                     <View
                       key={node.zoneId}
@@ -521,7 +557,12 @@ export function QueueMap(props: QueueMapProps) {
                   ))}
                 </View>
               ) : (
-                <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
                   {t("mapTab.web.emptySnapshot")}
                 </Text>
               )}

--- a/src/components/payments/payment-activity-list.tsx
+++ b/src/components/payments/payment-activity-list.tsx
@@ -1,8 +1,11 @@
-import { View } from "react-native";
+import { Pressable, View } from "react-native";
 import { useTranslation } from "react-i18next";
 import { ThemedText } from "@/components/themed-text";
-import { KitPressable } from "@/components/ui/kit";
-import { type BrandPalette, BrandRadius, BrandSpacing } from "@/constants/brand";
+import {
+  type BrandPalette,
+  BrandRadius,
+  BrandSpacing,
+} from "@/constants/brand";
 import type { Id } from "@/convex/_generated/dataModel";
 import { isSportType, toSportLabel } from "@/convex/constants";
 import { formatDateTime } from "@/lib/jobs-utils";
@@ -160,7 +163,9 @@ export function PaymentActivityList({
         <View style={{ paddingHorizontal: BrandSpacing.md, paddingBottom: 16 }}>
           {items.map((item, index) => {
             const paymentStatus = getPaymentStatusLabel(item.payment.status);
-            const payoutStatus = item.payout ? getPayoutStatusLabel(item.payout.status) : null;
+            const payoutStatus = item.payout
+              ? getPayoutStatusLabel(item.payout.status)
+              : null;
             const sportLabel = item.job
               ? isSportType(item.job.sport)
                 ? toSportLabel(item.job.sport)
@@ -178,16 +183,13 @@ export function PaymentActivityList({
                   zIndex: items.length - index,
                 }}
               >
-                <KitPressable
+                <Pressable
                   {...listItemPressProps}
                   accessibilityRole={onSelectPaymentId ? "button" : undefined}
-                  haptic={onSelectPaymentId ? "selection" : "none"}
-                  nativeFeedback={Boolean(onSelectPaymentId)}
-                  pressedOpacity={0.96}
-                  style={{
+                  style={({ pressed }) => ({
                     backgroundColor: palette.surface,
                     padding: 16,
-                    paddingBottom: 24, // extra padding at bottom because of overlap
+                    paddingBottom: 24,
                     borderRadius: 24,
                     borderCurve: "continuous",
                     borderWidth: 1,
@@ -195,18 +197,24 @@ export function PaymentActivityList({
                     flexDirection: "row",
                     alignItems: "center",
                     justifyContent: "space-between",
-                  }}
+                    opacity: pressed && onSelectPaymentId ? 0.96 : 1,
+                  })}
                 >
                   <View style={{ flex: 1, gap: 4 }}>
                     <ThemedText type="bodyStrong" style={{ fontSize: 18 }}>
                       {sportLabel}
                     </ThemedText>
-                    <ThemedText type="caption" style={{ color: palette.textMuted }}>
+                    <ThemedText
+                      type="caption"
+                      style={{ color: palette.textMuted }}
+                    >
                       {item.job
                         ? formatDateTime(item.job.startTime, locale)
                         : formatDateTime(item.payment.createdAt, locale)}
                     </ThemedText>
-                    <View style={{ flexDirection: "row", gap: 6, marginTop: 4 }}>
+                    <View
+                      style={{ flexDirection: "row", gap: 6, marginTop: 4 }}
+                    >
                       <StatusBadge
                         label={paymentStatus}
                         tone={getPaymentStatusTone(item.payment.status)}
@@ -226,7 +234,11 @@ export function PaymentActivityList({
                     <ThemedText
                       type="title"
                       selectable
-                      style={{ fontVariant: ["tabular-nums"], fontSize: 22, fontWeight: "700" }}
+                      style={{
+                        fontVariant: ["tabular-nums"],
+                        fontSize: 22,
+                        fontWeight: "700",
+                      }}
                     >
                       {viewerRole === "studio"
                         ? formatAgorotCurrency(
@@ -241,7 +253,10 @@ export function PaymentActivityList({
                           )}
                     </ThemedText>
                     {viewerRole === "studio" ? (
-                      <ThemedText type="caption" style={{ color: palette.textMuted }}>
+                      <ThemedText
+                        type="caption"
+                        style={{ color: palette.textMuted }}
+                      >
                         {`Payout ${formatAgorotCurrency(
                           item.payment.instructorBaseAmountAgorot,
                           locale,
@@ -250,7 +265,7 @@ export function PaymentActivityList({
                       </ThemedText>
                     ) : null}
                   </View>
-                </KitPressable>
+                </Pressable>
               </View>
             );
           })}

--- a/src/components/ui/address-autocomplete.tsx
+++ b/src/components/ui/address-autocomplete.tsx
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { type ColorValue, StyleSheet, TextInput, View } from "react-native";
+import {
+  type ColorValue,
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+} from "react-native";
 import { ThemedText } from "@/components/themed-text";
-import { KitPressable } from "@/components/ui/kit";
 import { useBrand } from "@/hooks/use-brand";
 import {
   fetchPlaceAutocomplete,
@@ -148,8 +153,15 @@ export function AddressAutocomplete({
         cursorColor={palette.primary as string}
       />
       {isLoading ? (
-        <View style={[styles.loadingBar, { backgroundColor: palette.primarySubtle }]}>
-          <ThemedText style={{ color: mutedTextColor ?? palette.textMuted, fontSize: 12 }}>
+        <View
+          style={[
+            styles.loadingBar,
+            { backgroundColor: palette.primarySubtle },
+          ]}
+        >
+          <ThemedText
+            style={{ color: mutedTextColor ?? palette.textMuted, fontSize: 12 }}
+          >
             {t("common.searching")}
           </ThemedText>
         </View>
@@ -165,12 +177,14 @@ export function AddressAutocomplete({
           ]}
         >
           {predictions.map((prediction) => (
-            <KitPressable
+            <Pressable
               key={prediction.placeId}
               style={({ pressed }) => [
                 styles.suggestion,
                 {
-                  backgroundColor: pressed ? palette.primarySubtle : "transparent",
+                  backgroundColor: pressed
+                    ? palette.primarySubtle
+                    : "transparent",
                 },
               ]}
               onPress={() => {
@@ -191,7 +205,7 @@ export function AddressAutocomplete({
                   {prediction.secondaryText}
                 </ThemedText>
               ) : null}
-            </KitPressable>
+            </Pressable>
           ))}
         </View>
       ) : null}

--- a/src/modules/navigation/role-tabs-layout.web.tsx
+++ b/src/modules/navigation/role-tabs-layout.web.tsx
@@ -1,11 +1,13 @@
 import { type Href, Link, Slot, usePathname } from "expo-router";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Text, View } from "react-native";
-import { KitPressable } from "@/components/ui/kit";
+import { Pressable, Text, View } from "react-native";
 import { TabBarScrollProvider } from "@/contexts/tab-bar-scroll-context";
 import { useBrand } from "@/hooks/use-brand";
-import { buildRoleTabRoute, type RoleTabRouteName } from "@/navigation/role-routes";
+import {
+  buildRoleTabRoute,
+  type RoleTabRouteName,
+} from "@/navigation/role-routes";
 import { getTabsForRole } from "@/navigation/tab-registry";
 import type { AppRole } from "@/navigation/types";
 
@@ -22,7 +24,10 @@ function formatDashboardDate(locale: string) {
   });
 }
 
-export function RoleTabsLayout({ appRole, badgeCountByRoute }: RoleTabsLayoutProps) {
+export function RoleTabsLayout({
+  appRole,
+  badgeCountByRoute,
+}: RoleTabsLayoutProps) {
   const palette = useBrand();
   const pathname = usePathname();
   const { t, i18n } = useTranslation();
@@ -91,7 +96,9 @@ export function RoleTabsLayout({ appRole, badgeCountByRoute }: RoleTabsLayoutPro
                   color: palette.text as string,
                 }}
               >
-                {appRole === "studio" ? "Studio dashboard" : "Instructor dashboard"}
+                {appRole === "studio"
+                  ? "Studio dashboard"
+                  : "Instructor dashboard"}
               </Text>
               <Text
                 style={{
@@ -156,10 +163,9 @@ export function RoleTabsLayout({ appRole, badgeCountByRoute }: RoleTabsLayoutPro
 
                 return (
                   <Link key={tab.id} href={route} asChild>
-                    <KitPressable
+                    <Pressable
                       accessibilityRole="link"
-                      pressStyle={{ transform: [{ scale: 0.99 }] }}
-                      style={{
+                      style={({ pressed }) => ({
                         borderRadius: 26,
                         borderCurve: "continuous",
                         backgroundColor: selected
@@ -167,7 +173,8 @@ export function RoleTabsLayout({ appRole, badgeCountByRoute }: RoleTabsLayoutPro
                           : (palette.surfaceAlt as string),
                         paddingHorizontal: 16,
                         paddingVertical: 14,
-                      }}
+                        transform: [{ scale: pressed ? 0.99 : 1 }],
+                      })}
                     >
                       <View
                         style={{
@@ -228,7 +235,7 @@ export function RoleTabsLayout({ appRole, badgeCountByRoute }: RoleTabsLayoutPro
                           </View>
                         ) : null}
                       </View>
-                    </KitPressable>
+                    </Pressable>
                   </Link>
                 );
               })}
@@ -318,7 +325,8 @@ export function RoleTabsLayout({ appRole, badgeCountByRoute }: RoleTabsLayoutPro
                     color: palette.textMuted as string,
                   }}
                 >
-                  Desktop mode is tuned for scanning, routing, and staying in flow.
+                  Desktop mode is tuned for scanning, routing, and staying in
+                  flow.
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
## Summary
- remove kit action wrappers from address autocomplete, payment activity, web tab navigation, queue map controls, and the performance hero card
- keep this slice tactical so the remaining kit work is isolated to the largest screen files
- update the audit execution log for the shared-surface slice

## Verification
- bun run typecheck
- confirmed no KitButton or KitPressable references remain in the touched files