### PR TITLE
UI Cut 09: simplify calendar action surfaces

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -532,6 +532,12 @@ Replace with consequence and momentum:
 - kept the slice tactical so the remaining work is concentrated in the largest screen files
 - reduced more interaction plumbing without expanding the abstraction surface
 
+### Slice 09
+
+- removed kit action wrappers from the main calendar screens on native and web
+- simplified week, date-picker, and agenda selection controls without changing calendar behavior
+- kept the slice mechanical so remaining map-tab and payments cleanup can stay isolated
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/components/calendar/calendar-tab-screen.tsx
+++ b/src/components/calendar/calendar-tab-screen.tsx
@@ -6,6 +6,7 @@ import {
   I18nManager,
   type LayoutChangeEvent,
   Platform,
+  Pressable,
   StyleSheet,
   Text,
   useWindowDimensions,
@@ -25,7 +26,8 @@ import { TabScreenRoot } from "@/components/layout/tab-screen-root";
 import { TopSheetSurface } from "@/components/layout/top-sheet-surface";
 import { LoadingScreen } from "@/components/loading-screen";
 import { AppSymbol } from "@/components/ui/app-symbol";
-import { KitButton, KitPressable, KitSegmentedToggle } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
+import { KitSegmentedToggle } from "@/components/ui/kit";
 import { triggerSelectionHaptic } from "@/components/ui/kit/native-interaction";
 import { BrandRadius, BrandSpacing, BrandType } from "@/constants/brand";
 import { useAppInsets } from "@/hooks/use-app-insets";
@@ -195,7 +197,10 @@ function WeekRail({
     () => weekDays.map((dayKey) => shiftDayKey(dayKey, -7)),
     [weekDays],
   );
-  const nextWeekDays = useMemo(() => weekDays.map((dayKey) => shiftDayKey(dayKey, 7)), [weekDays]);
+  const nextWeekDays = useMemo(
+    () => weekDays.map((dayKey) => shiftDayKey(dayKey, 7)),
+    [weekDays],
+  );
 
   const handleSwipeWeek = useCallback(
     (deltaWeeks: number) => {
@@ -237,14 +242,19 @@ function WeekRail({
             event.translationX <= -Math.max(SWIPE_THRESHOLD, width * 0.2) ||
             event.velocityX <= -650;
           const shouldRewind =
-            event.translationX >= Math.max(SWIPE_THRESHOLD, width * 0.2) || event.velocityX >= 650;
+            event.translationX >= Math.max(SWIPE_THRESHOLD, width * 0.2) ||
+            event.velocityX >= 650;
 
           if (shouldAdvance) {
-            translateX.value = withSpring(-width * 2, WEEK_RAIL_SPRING, (finished) => {
-              if (!finished) return;
-              translateX.value = -width;
-              runOnJS(handleSwipeWeek)(1);
-            });
+            translateX.value = withSpring(
+              -width * 2,
+              WEEK_RAIL_SPRING,
+              (finished) => {
+                if (!finished) return;
+                translateX.value = -width;
+                runOnJS(handleSwipeWeek)(1);
+              },
+            );
             return;
           }
 
@@ -283,7 +293,7 @@ function WeekRail({
 
           return (
             <Animated.View key={dayKey} style={{ flex: 1 }}>
-              <KitPressable
+              <Pressable
                 accessibilityRole="button"
                 accessibilityState={{ selected }}
                 accessibilityLabel={formatSelectedDayLabel(dayKey, locale)}
@@ -314,7 +324,9 @@ function WeekRail({
                   <Text
                     style={{
                       ...BrandType.micro,
-                      color: today ? (palette.text as string) : (palette.textMuted as string),
+                      color: today
+                        ? (palette.text as string)
+                        : (palette.textMuted as string),
                     }}
                   >
                     {formatWeekdayLetter(dayKey, locale)}
@@ -327,9 +339,13 @@ function WeekRail({
                       borderCurve: "continuous",
                       alignItems: "center",
                       justifyContent: "center",
-                      backgroundColor: selected ? (palette.text as string) : "transparent",
+                      backgroundColor: selected
+                        ? (palette.text as string)
+                        : "transparent",
                       borderWidth: today && !selected ? 1 : 0,
-                      borderColor: today ? (palette.borderStrong as string) : "transparent",
+                      borderColor: today
+                        ? (palette.borderStrong as string)
+                        : "transparent",
                     }}
                   >
                     <Text
@@ -339,7 +355,9 @@ function WeekRail({
                         lineHeight: 22,
                         fontVariant: ["tabular-nums"],
                         includeFontPadding: false,
-                        color: selected ? (palette.surface as string) : (palette.text as string),
+                        color: selected
+                          ? (palette.surface as string)
+                          : (palette.text as string),
                       }}
                     >
                       {formatDayNumber(dayKey)}
@@ -382,7 +400,7 @@ function WeekRail({
                     )}
                   </View>
                 </View>
-              </KitPressable>
+              </Pressable>
             </Animated.View>
           );
         })}
@@ -443,8 +461,12 @@ export function WeekStrip({
   const palette = useBrand();
   const { width: screenWidth } = useWindowDimensions();
   const todayKey = useMemo(() => toDayKey(Date.now()), []);
-  const selectedWeekStart = useMemo(() => getWeekStart(selectedDay), [selectedDay]);
-  const [displayedWeekStart, setDisplayedWeekStart] = useState(selectedWeekStart);
+  const selectedWeekStart = useMemo(
+    () => getWeekStart(selectedDay),
+    [selectedDay],
+  );
+  const [displayedWeekStart, setDisplayedWeekStart] =
+    useState(selectedWeekStart);
   const displayedWeekStartRef = useRef(selectedWeekStart);
   const [displayedSelectedDay, setDisplayedSelectedDay] = useState(selectedDay);
   const displayedSelectedDayRef = useRef(selectedDay);
@@ -460,9 +482,15 @@ export function WeekStrip({
   // 3-week triptych: prev, current, next
   const prevWeekStart = addDays(weekStart, -7);
   const nextWeekStart = addDays(weekStart, 7);
-  const prevWeekDays = useMemo(() => getWeekDays(prevWeekStart), [prevWeekStart]);
+  const prevWeekDays = useMemo(
+    () => getWeekDays(prevWeekStart),
+    [prevWeekStart],
+  );
   const currWeekDays = useMemo(() => getWeekDays(weekStart), [weekStart]);
-  const nextWeekDays = useMemo(() => getWeekDays(nextWeekStart), [nextWeekStart]);
+  const nextWeekDays = useMemo(
+    () => getWeekDays(nextWeekStart),
+    [nextWeekStart],
+  );
 
   // ─── Single unified pan gesture ──────────────────────────────────────
   const swipeX = useSharedValue(0);
@@ -483,11 +511,17 @@ export function WeekStrip({
   }, []);
   const commitWeekSwipe = useCallback(
     (deltaWeeks: number) => {
-      const nextWeekStart = addDays(displayedWeekStartRef.current, deltaWeeks * 7);
+      const nextWeekStart = addDays(
+        displayedWeekStartRef.current,
+        deltaWeeks * 7,
+      );
       displayedWeekStartRef.current = nextWeekStart;
       setDisplayedWeekStart(nextWeekStart);
 
-      const nextSelectedDay = addDays(displayedSelectedDayRef.current, deltaWeeks * 7);
+      const nextSelectedDay = addDays(
+        displayedSelectedDayRef.current,
+        deltaWeeks * 7,
+      );
       displayedSelectedDayRef.current = nextSelectedDay;
       setDisplayedSelectedDay(nextSelectedDay);
 
@@ -547,11 +581,17 @@ export function WeekStrip({
         const isExpanded = expandProgress.value > 0.5;
         const weekDelta = isExpanded ? 4 : 1; // month vs week navigation
 
-        if (e.translationX < -SWIPE_THRESHOLD || (e.velocityX < -500 && e.translationX < -20)) {
+        if (
+          e.translationX < -SWIPE_THRESHOLD ||
+          (e.velocityX < -500 && e.translationX < -20)
+        ) {
           swipeX.value = withTiming(-panelWidth, { duration: 200 }, () => {
             runOnJS(commitWeekSwipe)(weekDelta);
           });
-        } else if (e.translationX > SWIPE_THRESHOLD || (e.velocityX > 500 && e.translationX > 20)) {
+        } else if (
+          e.translationX > SWIPE_THRESHOLD ||
+          (e.velocityX > 500 && e.translationX > 20)
+        ) {
           swipeX.value = withTiming(panelWidth, { duration: 200 }, () => {
             runOnJS(commitWeekSwipe)(-weekDelta);
           });
@@ -597,19 +637,21 @@ export function WeekStrip({
     const lessonCount = lessonCountByDay.get(dayKey) ?? 0;
     const isCurrentMonth = isSameMonth(dayKey, displayedSelectedDay);
     const dimmed = !isCurrentMonth;
-    const dayDateLabel = new Date(dayKeyToTimestamp(dayKey)).toLocaleDateString(locale, {
-      weekday: "long",
-      month: "long",
-      day: "numeric",
-    });
+    const dayDateLabel = new Date(dayKeyToTimestamp(dayKey)).toLocaleDateString(
+      locale,
+      {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+      },
+    );
 
     return (
-      <KitPressable
+      <Pressable
         key={dayKey}
         accessibilityRole="button"
         accessibilityState={{ selected: isSelected }}
         accessibilityLabel={`${dayDateLabel}. ${lessonCount} events.`}
-        haptic="none"
         onPress={() => {
           onDayPress(dayKey);
           triggerSelectionHaptic();
@@ -646,11 +688,16 @@ export function WeekStrip({
           </Text>
         </View>
         {hasLessons && !isSelected ? (
-          <View style={[wStyles.dot, { backgroundColor: palette.primary as string }]} />
+          <View
+            style={[
+              wStyles.dot,
+              { backgroundColor: palette.primary as string },
+            ]}
+          />
         ) : (
           <View style={wStyles.dotSpacer} />
         )}
-      </KitPressable>
+      </Pressable>
     );
   };
 
@@ -666,7 +713,7 @@ export function WeekStrip({
     >
       {/* Header */}
       <View style={wStyles.headerRow}>
-        <KitPressable
+        <Pressable
           accessibilityRole="button"
           accessibilityLabel={monthButtonLabel}
           onPress={onMonthPress}
@@ -676,24 +723,39 @@ export function WeekStrip({
           <Text style={[wStyles.monthLabel, { color: palette.text as string }]}>
             {formatMonthYear(displayedSelectedDay, locale)}
           </Text>
-          <Text style={[wStyles.monthChevron, { color: palette.textMuted as string }]}>▾</Text>
-        </KitPressable>
+          <Text
+            style={[
+              wStyles.monthChevron,
+              { color: palette.textMuted as string },
+            ]}
+          >
+            ▾
+          </Text>
+        </Pressable>
         <View style={wStyles.headerActions}>
           {displayedSelectedDay !== todayKey ? (
-            <KitPressable
+            <Pressable
               accessibilityRole="button"
               accessibilityLabel={todayLabel}
               onPress={onTodayPress}
               hitSlop={6}
             >
               <View
-                style={[wStyles.todayPill, { backgroundColor: palette.primarySubtle as string }]}
+                style={[
+                  wStyles.todayPill,
+                  { backgroundColor: palette.primarySubtle as string },
+                ]}
               >
-                <Text style={[wStyles.todayPillText, { color: palette.primary as string }]}>
+                <Text
+                  style={[
+                    wStyles.todayPillText,
+                    { color: palette.primary as string },
+                  ]}
+                >
                   {todayLabel}
                 </Text>
               </View>
-            </KitPressable>
+            </Pressable>
           ) : null}
         </View>
       </View>
@@ -702,7 +764,12 @@ export function WeekStrip({
       <View style={wStyles.weekdayLabels}>
         {getWeekDays(getWeekStart(todayKey)).map((d) => (
           <View key={d} style={wStyles.weekdayLabelCell}>
-            <Text style={[wStyles.weekdayLabel, { color: palette.textMuted as string }]}>
+            <Text
+              style={[
+                wStyles.weekdayLabel,
+                { color: palette.textMuted as string },
+              ]}
+            >
               {formatWeekdayLetter(d, locale)}
             </Text>
           </View>
@@ -713,7 +780,12 @@ export function WeekStrip({
       <GestureDetector gesture={panGesture}>
         <Animated.View style={[{ overflow: "hidden" }, swipeStyle]}>
           {/* First row: triptych (prev | current | next) */}
-          <View style={[wStyles.triptych, { width: panelWidth * 3, marginLeft: -panelWidth }]}>
+          <View
+            style={[
+              wStyles.triptych,
+              { width: panelWidth * 3, marginLeft: -panelWidth },
+            ]}
+          >
             <View style={[wStyles.weekRow, { width: panelWidth }]}>
               {prevWeekDays.map((d) => renderDayCell(d, true))}
             </View>
@@ -737,11 +809,10 @@ export function WeekStrip({
       </GestureDetector>
 
       {/* Drag handle — enlarged touch target */}
-      <KitPressable
+      <Pressable
         style={wStyles.dragHandle}
         accessibilityRole="button"
         accessibilityLabel={dragHandleLabel}
-        haptic="none"
         onPress={() => {
           // Tap handle to toggle
           if (expandProgress.value > 0.5) {
@@ -759,8 +830,13 @@ export function WeekStrip({
         }}
         hitSlop={{ top: 12, bottom: 12, left: 40, right: 40 }}
       >
-        <View style={[wStyles.dragBar, { backgroundColor: palette.border as string }]} />
-      </KitPressable>
+        <View
+          style={[
+            wStyles.dragBar,
+            { backgroundColor: palette.border as string },
+          ]}
+        />
+      </Pressable>
     </Animated.View>
   );
 }
@@ -897,9 +973,14 @@ export default function CalendarTabScreen() {
     selectedDayTimestamp,
     isLoading,
   } = useCalendarTabController();
-  const selectedWeekDays = useMemo(() => getWeekDays(getWeekStart(selectedDay)), [selectedDay]);
+  const selectedWeekDays = useMemo(
+    () => getWeekDays(getWeekStart(selectedDay)),
+    [selectedDay],
+  );
   const [showDatePicker, setShowDatePicker] = useState(false);
-  const [pickerDate, setPickerDate] = useState(() => new Date(selectedDayTimestamp));
+  const [pickerDate, setPickerDate] = useState(
+    () => new Date(selectedDayTimestamp),
+  );
   const selectedLessonCount = lessonCountByDay.get(selectedDay) ?? 0;
 
   // ─── Render items ───────────────────────────────────────────────────────────
@@ -959,7 +1040,9 @@ export default function CalendarTabScreen() {
             <Text style={{ ...BrandType.title, color: palette.text as string }}>
               {t("calendarTab.agenda.title")}
             </Text>
-            <Text style={{ ...BrandType.micro, color: palette.textMuted as string }}>
+            <Text
+              style={{ ...BrandType.micro, color: palette.textMuted as string }}
+            >
               {formatSelectedDayLabel(selectedDay, i18n.language)}
             </Text>
           </View>
@@ -987,7 +1070,9 @@ export default function CalendarTabScreen() {
             >
               {selectedLessonCount === 1
                 ? t("calendarTab.agenda.oneSession")
-                : t("calendarTab.agenda.sessionCount", { count: selectedLessonCount })}
+                : t("calendarTab.agenda.sessionCount", {
+                    count: selectedLessonCount,
+                  })}
             </Text>
           </View>
         </View>
@@ -1000,7 +1085,9 @@ export default function CalendarTabScreen() {
     ({ item }: { item: TimelineListItem }) => {
       if (item.kind === "dayHeader") {
         const isToday = item.dayKey === todayKey;
-        const dotColor = isToday ? (palette.primary as string) : (palette.textMuted as string);
+        const dotColor = isToday
+          ? (palette.primary as string)
+          : (palette.textMuted as string);
 
         return (
           <View style={styles.timelineRow}>
@@ -1020,10 +1107,17 @@ export default function CalendarTabScreen() {
               />
             </View>
             <View style={styles.dayHeaderContent}>
-              <Text style={[styles.dayHeading, { color: palette.text as string }]}>
+              <Text
+                style={[styles.dayHeading, { color: palette.text as string }]}
+              >
                 {formatDayHeading(item.dayKey, i18n.language)}
               </Text>
-              <Text style={[styles.daySubtitle, { color: palette.textMuted as string }]}>
+              <Text
+                style={[
+                  styles.daySubtitle,
+                  { color: palette.textMuted as string },
+                ]}
+              >
                 {formatDaySubtitle(item.dayKey, i18n.language)}
               </Text>
             </View>
@@ -1033,21 +1127,40 @@ export default function CalendarTabScreen() {
 
       if (item.kind === "empty") {
         return (
-          <Animated.View entering={FadeInUp.duration(300).springify().damping(20)}>
+          <Animated.View
+            entering={FadeInUp.duration(300).springify().damping(20)}
+          >
             <View style={styles.timelineRow}>
               <View style={styles.railGutter}>
-                <View style={[styles.railLine, { backgroundColor: railColor }]} />
+                <View
+                  style={[styles.railLine, { backgroundColor: railColor }]}
+                />
               </View>
-              <View style={[styles.emptyStateCard, { backgroundColor: palette.surface as string }]}>
+              <View
+                style={[
+                  styles.emptyStateCard,
+                  { backgroundColor: palette.surface as string },
+                ]}
+              >
                 <AppSymbol
                   name="calendar.badge.exclamationmark"
                   size={28}
                   tintColor={palette.textMuted as string}
                 />
-                <Text style={[styles.emptyStateTitle, { color: palette.textMuted as string }]}>
+                <Text
+                  style={[
+                    styles.emptyStateTitle,
+                    { color: palette.textMuted as string },
+                  ]}
+                >
                   {t("calendarTab.timeline.noLessons")}
                 </Text>
-                <Text style={[styles.emptyStateBody, { color: palette.textMuted as string }]}>
+                <Text
+                  style={[
+                    styles.emptyStateBody,
+                    { color: palette.textMuted as string },
+                  ]}
+                >
                   {t("calendarTab.timeline.noLessonsHint")}
                 </Text>
               </View>
@@ -1058,8 +1171,11 @@ export default function CalendarTabScreen() {
 
       const row = item.lesson;
       const swatches = palette.calendar.eventSwatches;
-      const swatch = swatches[hashSport(row.sport) % Math.max(swatches.length, 1)] ?? undefined;
-      const accent = (swatch?.background as string) ?? (palette.primary as string);
+      const swatch =
+        swatches[hashSport(row.sport) % Math.max(swatches.length, 1)] ??
+        undefined;
+      const accent =
+        (swatch?.background as string) ?? (palette.primary as string);
       const counterpart =
         row.source === "google"
           ? (row.location ?? t("calendarTab.googleCalendar"))
@@ -1106,7 +1222,7 @@ export default function CalendarTabScreen() {
             <View style={[styles.railLine, { backgroundColor: railColor }]} />
             <View style={[styles.railDotLesson, { backgroundColor: accent }]} />
           </View>
-          <KitPressable
+          <Pressable
             accessibilityRole="button"
             accessibilityLabel={t("calendarTab.lessonRowAccessibility", {
               sport: row.sport,
@@ -1115,11 +1231,19 @@ export default function CalendarTabScreen() {
             })}
             accessibilityHint={t("calendarTab.lessonRowAccessibilityHint")}
             onPress={() => handleDayPress(item.dayKey)}
-            style={[styles.lessonCard, { backgroundColor: palette.surfaceElevated as string }]}
+            style={[
+              styles.lessonCard,
+              { backgroundColor: palette.surfaceElevated as string },
+            ]}
           >
             <View style={styles.lessonContent}>
               <View style={styles.lessonTopRow}>
-                <Text style={[styles.lessonTime, { color: palette.textMuted as string }]}>
+                <Text
+                  style={[
+                    styles.lessonTime,
+                    { color: palette.textMuted as string },
+                  ]}
+                >
                   {timeLabel}
                 </Text>
                 <View style={styles.lessonBadgeRow}>
@@ -1130,26 +1254,48 @@ export default function CalendarTabScreen() {
                         { backgroundColor: palette.primarySubtle as string },
                       ]}
                     >
-                      <Text style={[styles.sourceBadgeText, { color: palette.primary as string }]}>
+                      <Text
+                        style={[
+                          styles.sourceBadgeText,
+                          { color: palette.primary as string },
+                        ]}
+                      >
                         {t("calendarTab.timeline.googleBadge")}
                       </Text>
                     </View>
                   ) : null}
-                  <View style={[styles.lifecycleBadge, { backgroundColor: lifecycleTone.bg }]}>
-                    <Text style={[styles.lifecycleBadgeText, { color: lifecycleTone.fg }]}>
+                  <View
+                    style={[
+                      styles.lifecycleBadge,
+                      { backgroundColor: lifecycleTone.bg },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.lifecycleBadgeText,
+                        { color: lifecycleTone.fg },
+                      ]}
+                    >
                       {lifecycleLabel}
                     </Text>
                   </View>
                 </View>
               </View>
-              <Text style={[styles.lessonTitle, { color: palette.text as string }]}>
+              <Text
+                style={[styles.lessonTitle, { color: palette.text as string }]}
+              >
                 {row.sport}
               </Text>
-              <Text style={[styles.lessonMeta, { color: palette.textMuted as string }]}>
+              <Text
+                style={[
+                  styles.lessonMeta,
+                  { color: palette.textMuted as string },
+                ]}
+              >
                 {counterpart}
               </Text>
             </View>
-          </KitPressable>
+          </Pressable>
         </View>
       );
     },
@@ -1164,9 +1310,24 @@ export default function CalendarTabScreen() {
 
   if (isDesktopWeb) {
     return (
-      <TabScreenRoot mode="static" style={{ backgroundColor: palette.surface as string }}>
-        <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 24 }}>
-          <Text style={{ ...BrandType.bodyStrong, color: palette.textMuted as string }}>
+      <TabScreenRoot
+        mode="static"
+        style={{ backgroundColor: palette.surface as string }}
+      >
+        <View
+          style={{
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            padding: 24,
+          }}
+        >
+          <Text
+            style={{
+              ...BrandType.bodyStrong,
+              color: palette.textMuted as string,
+            }}
+          >
             {t("calendarTab.desktopSoon")}
           </Text>
         </View>
@@ -1177,7 +1338,11 @@ export default function CalendarTabScreen() {
   // ─── Render ─────────────────────────────────────────────────────────────────
 
   return (
-    <TabScreenRoot mode="static" topInsetTone="sheet" style={{ backgroundColor: palette.appBg }}>
+    <TabScreenRoot
+      mode="static"
+      topInsetTone="sheet"
+      style={{ backgroundColor: palette.appBg }}
+    >
       <TopSheetSurface
         style={{
           paddingHorizontal: BrandSpacing.lg,
@@ -1207,23 +1372,31 @@ export default function CalendarTabScreen() {
               >
                 {formatMonthYear(selectedDay, i18n.language)}
               </Text>
-              <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+              <Text
+                style={{
+                  ...BrandType.caption,
+                  color: palette.textMuted as string,
+                }}
+              >
                 {formatSelectedDayLabel(selectedDay, i18n.language)}
               </Text>
             </View>
 
             <View style={{ alignItems: "flex-end", gap: BrandSpacing.sm }}>
               {selectedDay !== todayKey ? (
-                <KitButton
+                <ActionButton
                   label={t("common.today")}
                   onPress={handleTodayPress}
-                  variant="secondary"
-                  size="sm"
-                  fullWidth={false}
+                  palette={palette}
+                  tone="secondary"
                 />
               ) : null}
-              <KitButton
-                label={showDatePicker ? t("common.done") : t("calendarTab.header.chooseDate")}
+              <ActionButton
+                label={
+                  showDatePicker
+                    ? t("common.done")
+                    : t("calendarTab.header.chooseDate")
+                }
                 onPress={() => {
                   if (showDatePicker) {
                     handleDoneWithDatePicker();
@@ -1232,9 +1405,8 @@ export default function CalendarTabScreen() {
                   setShowDatePicker(true);
                   openMonthPicker();
                 }}
-                variant="secondary"
-                size="sm"
-                fullWidth={false}
+                palette={palette}
+                tone="secondary"
               />
             </View>
           </View>
@@ -1250,7 +1422,9 @@ export default function CalendarTabScreen() {
               paddingTop: BrandSpacing.md,
             }}
           >
-            <Text style={{ ...BrandType.bodyStrong, color: palette.text as string }}>
+            <Text
+              style={{ ...BrandType.bodyStrong, color: palette.text as string }}
+            >
               {formatSelectedDayLabel(selectedDay, i18n.language)}
             </Text>
             <View
@@ -1277,7 +1451,9 @@ export default function CalendarTabScreen() {
               >
                 {selectedLessonCount === 1
                   ? t("calendarTab.agenda.oneSession")
-                  : t("calendarTab.agenda.sessionCount", { count: selectedLessonCount })}
+                  : t("calendarTab.agenda.sessionCount", {
+                      count: selectedLessonCount,
+                    })}
               </Text>
             </View>
           </View>
@@ -1327,12 +1503,17 @@ export default function CalendarTabScreen() {
               onChange={handleDateChange}
             />
             {Platform.OS === "ios" ? (
-              <View style={{ alignItems: "flex-end", paddingHorizontal: 14, paddingBottom: 14 }}>
-                <KitButton
+              <View
+                style={{
+                  alignItems: "flex-end",
+                  paddingHorizontal: 14,
+                  paddingBottom: 14,
+                }}
+              >
+                <ActionButton
                   label={t("common.done")}
                   onPress={handleDoneWithDatePicker}
-                  size="sm"
-                  fullWidth={false}
+                  palette={palette}
                 />
               </View>
             ) : null}
@@ -1340,7 +1521,12 @@ export default function CalendarTabScreen() {
         ) : null}
       </TopSheetSurface>
 
-      <View style={[styles.timelineViewport, { backgroundColor: palette.appBg as string }]}>
+      <View
+        style={[
+          styles.timelineViewport,
+          { backgroundColor: palette.appBg as string },
+        ]}
+      >
         <FlashList
           ref={listRef}
           data={listItems}
@@ -1367,7 +1553,10 @@ export default function CalendarTabScreen() {
         />
         <View
           pointerEvents="none"
-          style={[styles.timelineBottomMask, { backgroundColor: palette.appBg as string }]}
+          style={[
+            styles.timelineBottomMask,
+            { backgroundColor: palette.appBg as string },
+          ]}
         />
       </View>
     </TabScreenRoot>

--- a/src/components/calendar/calendar-web-board.tsx
+++ b/src/components/calendar/calendar-web-board.tsx
@@ -1,8 +1,8 @@
 import DateTimePicker from "@react-native-community/datetimepicker";
 import { useMemo } from "react";
-import { ScrollView, Text, View } from "react-native";
+import { Pressable, ScrollView, Text, View } from "react-native";
 
-import { KitButton, KitPressable } from "@/components/ui/kit";
+import { ActionButton } from "@/components/ui/action-button";
 import { BrandType } from "@/constants/brand";
 import { useBrand } from "@/hooks/use-brand";
 import { formatTime } from "@/lib/jobs-utils";
@@ -42,8 +42,14 @@ function formatMonthLabel(dayKey: string, locale: string) {
 function formatWeekRangeLabel(weekDays: string[], locale: string) {
   const start = new Date(dayKeyToTimestamp(weekDays[0] ?? ""));
   const end = new Date(dayKeyToTimestamp(weekDays[weekDays.length - 1] ?? ""));
-  const startLabel = start.toLocaleDateString(locale, { month: "short", day: "numeric" });
-  const endLabel = end.toLocaleDateString(locale, { month: "short", day: "numeric" });
+  const startLabel = start.toLocaleDateString(locale, {
+    month: "short",
+    day: "numeric",
+  });
+  const endLabel = end.toLocaleDateString(locale, {
+    month: "short",
+    day: "numeric",
+  });
   return `${startLabel} - ${endLabel}`;
 }
 
@@ -56,7 +62,9 @@ function formatSelectedDayLabel(dayKey: string, locale: string) {
 }
 
 function formatWeekdayLabel(dayKey: string, locale: string) {
-  return new Date(dayKeyToTimestamp(dayKey)).toLocaleDateString(locale, { weekday: "short" });
+  return new Date(dayKeyToTimestamp(dayKey)).toLocaleDateString(locale, {
+    weekday: "short",
+  });
 }
 
 function formatDayNumber(dayKey: string) {
@@ -77,7 +85,9 @@ function formatHoursMetric(hours: number) {
   if (rounded === 0) {
     return "0h";
   }
-  return Number.isInteger(rounded) ? `${String(rounded)}h` : `${rounded.toFixed(1)}h`;
+  return Number.isInteger(rounded)
+    ? `${String(rounded)}h`
+    : `${rounded.toFixed(1)}h`;
 }
 
 function hashSport(sport: string) {
@@ -90,15 +100,22 @@ function hashSport(sport: string) {
 
 function getRowsForSection(section: AgendaSection | undefined) {
   if (!section) return [] as TimelineRow[];
-  return section.data.flatMap((item) => (item.kind === "lesson" ? [item.lesson] : []));
+  return section.data.flatMap((item) =>
+    item.kind === "lesson" ? [item.lesson] : [],
+  );
 }
 
 function getDurationHours(rows: TimelineRow[]) {
-  return rows.reduce((total, row) => total + (row.endTime - row.startTime) / 3_600_000, 0);
+  return rows.reduce(
+    (total, row) => total + (row.endTime - row.startTime) / 3_600_000,
+    0,
+  );
 }
 
 function buildLaneLayout(rows: TimelineRow[]) {
-  const sorted = [...rows].sort((a, b) => a.startTime - b.startTime || a.endTime - b.endTime);
+  const sorted = [...rows].sort(
+    (a, b) => a.startTime - b.startTime || a.endTime - b.endTime,
+  );
   const laneEndTimes: number[] = [];
   const laneAssignments = new Map<string, number>();
 
@@ -136,7 +153,10 @@ function resolveGridBounds(rows: TimelineRow[]) {
     latestHour = Math.max(latestHour, endHour);
   });
 
-  const gridStartHour = Math.max(MIN_GRID_START_HOUR, Math.floor(earliestHour) - 1);
+  const gridStartHour = Math.max(
+    MIN_GRID_START_HOUR,
+    Math.floor(earliestHour) - 1,
+  );
   const gridEndHour = Math.min(MAX_GRID_END_HOUR, Math.ceil(latestHour) + 1);
 
   return {
@@ -212,10 +232,17 @@ function MetricTile({
   );
 }
 
-function FocusAgendaCard({ locale, row }: { locale: string; row: TimelineRow }) {
+function FocusAgendaCard({
+  locale,
+  row,
+}: {
+  locale: string;
+  row: TimelineRow;
+}) {
   const palette = useBrand();
   const swatches = palette.calendar.eventSwatches;
-  const swatch = swatches[hashSport(row.sport) % Math.max(swatches.length, 1)] ?? undefined;
+  const swatch =
+    swatches[hashSport(row.sport) % Math.max(swatches.length, 1)] ?? undefined;
   const accent = (swatch?.background as string) ?? (palette.primary as string);
 
   return (
@@ -237,10 +264,16 @@ function FocusAgendaCard({ locale, row }: { locale: string; row: TimelineRow }) 
           backgroundColor: accent,
         }}
       />
-      <Text style={{ ...BrandType.title, color: palette.text as string }} numberOfLines={1}>
+      <Text
+        style={{ ...BrandType.title, color: palette.text as string }}
+        numberOfLines={1}
+      >
         {row.sport}
       </Text>
-      <Text style={{ ...BrandType.caption, color: palette.textMuted as string }} numberOfLines={2}>
+      <Text
+        style={{ ...BrandType.caption, color: palette.textMuted as string }}
+        numberOfLines={2}
+      >
         {row.roleView === "instructor"
           ? row.studioName
           : (row.instructorName ?? "Unassigned instructor")}
@@ -287,24 +320,40 @@ export function CalendarWebBoard({
     [sectionMap, weekDays],
   );
   const selectedRows = useMemo(
-    () => weekRowsByDay.find((entry) => entry.dayKey === selectedDay)?.rows ?? [],
+    () =>
+      weekRowsByDay.find((entry) => entry.dayKey === selectedDay)?.rows ?? [],
     [selectedDay, weekRowsByDay],
   );
-  const weekRows = useMemo(() => weekRowsByDay.flatMap((entry) => entry.rows), [weekRowsByDay]);
+  const weekRows = useMemo(
+    () => weekRowsByDay.flatMap((entry) => entry.rows),
+    [weekRowsByDay],
+  );
   const weekSessionCount = weekRows.length;
-  const busyDayCount = weekRowsByDay.filter((entry) => entry.rows.length > 0).length;
+  const busyDayCount = weekRowsByDay.filter(
+    (entry) => entry.rows.length > 0,
+  ).length;
   const weekBookedHours = getDurationHours(weekRows);
   const selectedBookedHours = getDurationHours(selectedRows);
-  const { gridStartHour, gridEndHour } = useMemo(() => resolveGridBounds(weekRows), [weekRows]);
+  const { gridStartHour, gridEndHour } = useMemo(
+    () => resolveGridBounds(weekRows),
+    [weekRows],
+  );
   const hours = useMemo(
-    () => Array.from({ length: gridEndHour - gridStartHour }, (_, index) => gridStartHour + index),
+    () =>
+      Array.from(
+        { length: gridEndHour - gridStartHour },
+        (_, index) => gridStartHour + index,
+      ),
     [gridEndHour, gridStartHour],
   );
   const gridHeight = hours.length * HOUR_ROW_HEIGHT;
   const now = Date.now();
   const todayOffsetHours =
-    new Date(now).getHours() + new Date(now).getMinutes() / 60 + new Date(now).getSeconds() / 3600;
-  const showNowLine = todayOffsetHours >= gridStartHour && todayOffsetHours <= gridEndHour;
+    new Date(now).getHours() +
+    new Date(now).getMinutes() / 60 +
+    new Date(now).getSeconds() / 3600;
+  const showNowLine =
+    todayOffsetHours >= gridStartHour && todayOffsetHours <= gridEndHour;
 
   return (
     <View
@@ -354,17 +403,31 @@ export function CalendarWebBoard({
           >
             {formatMonthLabel(selectedDay, locale)}
           </Text>
-          <Text style={{ ...BrandType.body, color: palette.textMuted as string }}>
-            {formatWeekRangeLabel(weekDays, locale)}. One horizontal surface for scan, select, and
-            adjust.
+          <Text
+            style={{ ...BrandType.body, color: palette.textMuted as string }}
+          >
+            {formatWeekRangeLabel(weekDays, locale)}. One horizontal surface for
+            scan, select, and adjust.
           </Text>
         </View>
 
-        <MetricTile label="Week load" value={formatHoursMetric(weekBookedHours)} tone="light" />
-        <MetricTile label="Active days" value={`${String(busyDayCount)}/7`} tone="accent" />
+        <MetricTile
+          label="Week load"
+          value={formatHoursMetric(weekBookedHours)}
+          tone="light"
+        />
+        <MetricTile
+          label="Active days"
+          value={`${String(busyDayCount)}/7`}
+          tone="accent"
+        />
         <MetricTile
           label="Focus"
-          value={selectedRows.length === 0 ? "OPEN" : formatHoursMetric(selectedBookedHours)}
+          value={
+            selectedRows.length === 0
+              ? "OPEN"
+              : formatHoursMetric(selectedBookedHours)
+          }
           tone="dark"
         />
       </View>
@@ -393,10 +456,18 @@ export function CalendarWebBoard({
           >
             Focus day
           </Text>
-          <Text style={{ ...BrandType.heading, fontSize: 24, color: palette.text as string }}>
+          <Text
+            style={{
+              ...BrandType.heading,
+              fontSize: 24,
+              color: palette.text as string,
+            }}
+          >
             {formatSelectedDayLabel(selectedDay, locale)}
           </Text>
-          <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
+          <Text
+            style={{ ...BrandType.caption, color: palette.textMuted as string }}
+          >
             {selectedRows.length === 0
               ? "No sessions are stacked here yet."
               : selectedRows.length === 1
@@ -406,34 +477,28 @@ export function CalendarWebBoard({
         </View>
 
         <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
-          <KitButton
+          <ActionButton
             label="Prev week"
             onPress={() => onChangeWeek(-1)}
-            variant="secondary"
-            size="sm"
-            fullWidth={false}
+            palette={palette}
+            tone="secondary"
           />
-          <KitButton
+          <ActionButton
             label={showDatePicker ? "Done" : "Jump to date"}
             onPress={onToggleDatePicker}
-            variant="secondary"
-            size="sm"
-            fullWidth={false}
+            palette={palette}
+            tone="secondary"
           />
-          <KitButton
+          <ActionButton
             label="Today"
             onPress={onTodayPress}
-            variant="secondary"
-            size="sm"
-            fullWidth={false}
-            style={{ backgroundColor: palette.surface as string }}
+            palette={palette}
+            tone="secondary"
           />
-          <KitButton
+          <ActionButton
             label="Next week"
             onPress={() => onChangeWeek(1)}
-            variant="primary"
-            size="sm"
-            fullWidth={false}
+            palette={palette}
           />
         </View>
       </View>
@@ -462,14 +527,17 @@ export function CalendarWebBoard({
               paddingBottom: 18,
             }}
           >
-            <KitButton
+            <ActionButton
               label="Close"
               onPress={onDismissDatePicker}
-              variant="secondary"
-              size="sm"
-              fullWidth={false}
+              palette={palette}
+              tone="secondary"
             />
-            <KitButton label="Apply" onPress={onToggleDatePicker} size="sm" fullWidth={false} />
+            <ActionButton
+              label="Apply"
+              onPress={onToggleDatePicker}
+              palette={palette}
+            />
           </View>
         </View>
       ) : null}
@@ -506,21 +574,32 @@ export function CalendarWebBoard({
             >
               Selected agenda
             </Text>
-            <Text style={{ ...BrandType.heading, fontSize: 24, color: palette.surface as string }}>
+            <Text
+              style={{
+                ...BrandType.heading,
+                fontSize: 24,
+                color: palette.surface as string,
+              }}
+            >
               {selectedRows.length === 0
                 ? "Open lane"
                 : selectedRows.length === 1
                   ? "1 session"
                   : `${String(selectedRows.length)} sessions`}
             </Text>
-            <Text style={{ ...BrandType.caption, color: "rgba(255,255,255,0.72)" }}>
+            <Text
+              style={{ ...BrandType.caption, color: "rgba(255,255,255,0.72)" }}
+            >
               {selectedRows.length === 0
                 ? "A clear day gives you room to absorb new demand."
                 : `${formatHoursMetric(selectedBookedHours)} booked across the selected day.`}
             </Text>
           </View>
 
-          <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ gap: 10 }}>
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={{ gap: 10 }}
+          >
             {selectedRows.length === 0 ? (
               <View
                 style={{
@@ -532,11 +611,22 @@ export function CalendarWebBoard({
                   gap: 4,
                 }}
               >
-                <Text style={{ ...BrandType.bodyStrong, color: palette.text as string }}>
+                <Text
+                  style={{
+                    ...BrandType.bodyStrong,
+                    color: palette.text as string,
+                  }}
+                >
                   Nothing booked
                 </Text>
-                <Text style={{ ...BrandType.caption, color: palette.textMuted as string }}>
-                  Switch days directly from the planner header to review the rest of the week.
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  Switch days directly from the planner header to review the
+                  rest of the week.
                 </Text>
               </View>
             ) : (
@@ -589,7 +679,12 @@ export function CalendarWebBoard({
                         {formatHourLabel(hour, locale)}
                       </Text>
                       {index === 0 ? (
-                        <Text style={{ ...BrandType.micro, color: palette.textMuted as string }}>
+                        <Text
+                          style={{
+                            ...BrandType.micro,
+                            color: palette.textMuted as string,
+                          }}
+                        >
                           {`${String(weekSessionCount)} total`}
                         </Text>
                       ) : null}
@@ -601,13 +696,18 @@ export function CalendarWebBoard({
                   const { laneAssignments, laneCount } = buildLaneLayout(rows);
                   const dayLoadHours = getDurationHours(rows);
                   const laneWidth =
-                    laneCount > 1 ? (DAY_COLUMN_WIDTH - 28) / laneCount : DAY_COLUMN_WIDTH - 28;
+                    laneCount > 1
+                      ? (DAY_COLUMN_WIDTH - 28) / laneCount
+                      : DAY_COLUMN_WIDTH - 28;
                   const selected = dayKey === selectedDay;
                   const today = dayKey === todayKey;
 
                   return (
-                    <View key={dayKey} style={{ width: DAY_COLUMN_WIDTH, marginRight: 12 }}>
-                      <KitPressable
+                    <View
+                      key={dayKey}
+                      style={{ width: DAY_COLUMN_WIDTH, marginRight: 12 }}
+                    >
+                      <Pressable
                         accessibilityRole="button"
                         accessibilityState={{ selected }}
                         onPress={() => onSelectDay(dayKey)}
@@ -677,7 +777,7 @@ export function CalendarWebBoard({
                             </Text>
                           </View>
                         </View>
-                      </KitPressable>
+                      </Pressable>
 
                       <View
                         style={{
@@ -716,7 +816,9 @@ export function CalendarWebBoard({
                               position: "absolute",
                               left: 12,
                               right: 12,
-                              top: (todayOffsetHours - gridStartHour) * HOUR_ROW_HEIGHT,
+                              top:
+                                (todayOffsetHours - gridStartHour) *
+                                HOUR_ROW_HEIGHT,
                               height: 2,
                               borderRadius: 999,
                               backgroundColor: palette.primary as string,
@@ -728,19 +830,29 @@ export function CalendarWebBoard({
                           const lane = laneAssignments.get(row.lessonId) ?? 0;
                           const dayStart = dayKeyToTimestamp(dayKey);
                           const startHourOffset =
-                            (row.startTime - dayStart) / 3_600_000 - gridStartHour;
+                            (row.startTime - dayStart) / 3_600_000 -
+                            gridStartHour;
                           const durationHours = Math.max(
                             0.75,
                             (row.endTime - row.startTime) / 3_600_000,
                           );
                           const swatches = palette.calendar.eventSwatches;
                           const swatch =
-                            swatches[hashSport(row.sport) % Math.max(swatches.length, 1)] ??
-                            undefined;
+                            swatches[
+                              hashSport(row.sport) %
+                                Math.max(swatches.length, 1)
+                            ] ?? undefined;
                           const accent =
-                            (swatch?.background as string) ?? (palette.primary as string);
-                          const top = Math.max(8, startHourOffset * HOUR_ROW_HEIGHT + 8);
-                          const height = Math.max(58, durationHours * HOUR_ROW_HEIGHT - 10);
+                            (swatch?.background as string) ??
+                            (palette.primary as string);
+                          const top = Math.max(
+                            8,
+                            startHourOffset * HOUR_ROW_HEIGHT + 8,
+                          );
+                          const height = Math.max(
+                            58,
+                            durationHours * HOUR_ROW_HEIGHT - 10,
+                          );
 
                           return (
                             <View
@@ -788,7 +900,8 @@ export function CalendarWebBoard({
                               >
                                 {row.roleView === "instructor"
                                   ? row.studioName
-                                  : (row.instructorName ?? "Unassigned instructor")}
+                                  : (row.instructorName ??
+                                    "Unassigned instructor")}
                               </Text>
                             </View>
                           );


### PR DESCRIPTION
## Summary
- remove KitButton and KitPressable usage from the main calendar screens
- swap calendar header and picker actions to ActionButton and native Pressable
- update the brutal audit doc with the calendar slice

## Validation
- bun run typecheck