### PR TITLE
UI Cut 11: simplify instructor payment interactions

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -544,6 +544,12 @@ Replace with consequence and momentum:
 - simplified territory selection, list rows, and bottom-sheet controls to plain pressables and action buttons
 - reduced map editing ceremony without changing zone selection or save flow
 
+### Slice 11
+
+- removed kit pressable usage from the instructor payments screen
+- simplified payout, bank, schedule, and receipt actions to native pressables while keeping payout logic intact
+- reduced one of the heaviest profile screens without changing payment state or hosted onboarding flow
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/payments.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/payments.tsx
@@ -6,13 +6,13 @@ import { Redirect, useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Platform, View } from "react-native";
+import { Alert, Platform, Pressable, View } from "react-native";
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
 import { PaymentActivityList } from "@/components/payments/payment-activity-list";
 import { ThemedText } from "@/components/themed-text";
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import { KitPressable, KitSegmentedToggle, KitSuccessBurst } from "@/components/ui/kit";
+import { KitSegmentedToggle, KitSuccessBurst } from "@/components/ui/kit";
 import { BrandSpacing } from "@/constants/brand";
 import { useRapydReturn } from "@/contexts/rapyd-return-context";
 import { api } from "@/convex/_generated/api";
@@ -24,12 +24,19 @@ import {
   getPaymentStatusLabel,
   getPayoutStatusLabel,
 } from "@/lib/payments-utils";
-import { buildRapydBridgeUrl, resolveRapydAppReturnUrl } from "@/lib/rapyd-hosted-flow";
+import {
+  buildRapydBridgeUrl,
+  resolveRapydAppReturnUrl,
+} from "@/lib/rapyd-hosted-flow";
 
 WebBrowser.maybeCompleteAuthSession();
 
-const INSTRUCTOR_IDENTITY_VERIFICATION_ROUTE = "/instructor/profile/identity-verification" as const;
-type PayoutPreferenceMode = "immediate_when_eligible" | "scheduled_date" | "manual_hold";
+const INSTRUCTOR_IDENTITY_VERIFICATION_ROUTE =
+  "/instructor/profile/identity-verification" as const;
+type PayoutPreferenceMode =
+  | "immediate_when_eligible"
+  | "scheduled_date"
+  | "manual_hold";
 
 function buildDefaultScheduledDate(timestamp?: number | null) {
   if (timestamp && Number.isFinite(timestamp) && timestamp > Date.now()) {
@@ -49,8 +56,10 @@ export default function ProfilePaymentsScreen() {
 
   const currentUser = useQuery(api.users.getCurrentUser);
   const isInstructorPaymentsRole = currentUser?.role === "instructor";
-  const { consumeReturn: consumeBeneficiaryReturn, latestReturn: latestBeneficiaryReturn } =
-    useRapydReturn("beneficiary");
+  const {
+    consumeReturn: consumeBeneficiaryReturn,
+    latestReturn: latestBeneficiaryReturn,
+  } = useRapydReturn("beneficiary");
 
   const paymentRows = useQuery(
     api.payments.listMyPayments,
@@ -60,8 +69,12 @@ export default function ProfilePaymentsScreen() {
     api.payments.getMyPayoutSummary,
     currentUser?.role === "instructor" ? {} : "skip",
   );
-  const requestPayoutWithdrawal = useMutation(api.payments.requestMyPayoutWithdrawal);
-  const upsertMyPayoutPreference = useMutation(api.payments.upsertMyPayoutPreference);
+  const requestPayoutWithdrawal = useMutation(
+    api.payments.requestMyPayoutWithdrawal,
+  );
+  const upsertMyPayoutPreference = useMutation(
+    api.payments.upsertMyPayoutPreference,
+  );
   const createBeneficiaryOnboardingForInstructor = useAction(
     api.rapyd.createBeneficiaryOnboardingForInstructor,
   );
@@ -78,12 +91,14 @@ export default function ProfilePaymentsScreen() {
   const [preferenceBusy, setPreferenceBusy] = useState(false);
   const [preferenceError, setPreferenceError] = useState<string | null>(null);
   const [preferenceInfo, setPreferenceInfo] = useState<string | null>(null);
-  const [pendingPreferenceMode, setPendingPreferenceMode] = useState<PayoutPreferenceMode | null>(
-    null,
-  );
+  const [pendingPreferenceMode, setPendingPreferenceMode] =
+    useState<PayoutPreferenceMode | null>(null);
   const [showSchedulePicker, setShowSchedulePicker] = useState(false);
-  const [scheduleDraft, setScheduleDraft] = useState<Date>(buildDefaultScheduledDate());
-  const [selectedPaymentId, setSelectedPaymentId] = useState<Id<"payments"> | null>(null);
+  const [scheduleDraft, setScheduleDraft] = useState<Date>(
+    buildDefaultScheduledDate(),
+  );
+  const [selectedPaymentId, setSelectedPaymentId] =
+    useState<Id<"payments"> | null>(null);
 
   const selectedPaymentDetail = useQuery(
     api.payments.getMyPaymentDetail,
@@ -104,7 +119,9 @@ export default function ProfilePaymentsScreen() {
       setDestinationInfo(t("profile.payments.connectSuccess"));
       setShowOnboardingSuccess(true);
       if (Platform.OS === "ios") {
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        void Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        );
       }
       return;
     }
@@ -143,17 +160,26 @@ export default function ProfilePaymentsScreen() {
   }, [consumeBeneficiaryReturn, latestBeneficiaryReturn, t]);
 
   useEffect(() => {
-    if (!isFinalizingOnboarding || activeOnboardingId !== null || !payoutSummary) {
+    if (
+      !isFinalizingOnboarding ||
+      activeOnboardingId !== null ||
+      !payoutSummary
+    ) {
       return;
     }
 
-    if (payoutSummary.hasVerifiedDestination || payoutSummary.onboardingStatus === "completed") {
+    if (
+      payoutSummary.hasVerifiedDestination ||
+      payoutSummary.onboardingStatus === "completed"
+    ) {
       setIsFinalizingOnboarding(false);
       setDestinationError(null);
       setDestinationInfo(t("profile.payments.connectSuccess"));
       setShowOnboardingSuccess(true);
       if (Platform.OS === "ios") {
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        void Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        );
       }
       return;
     }
@@ -185,7 +211,9 @@ export default function ProfilePaymentsScreen() {
     if (!payoutSummary || pendingPreferenceMode === "scheduled_date") {
       return;
     }
-    setScheduleDraft(buildDefaultScheduledDate(payoutSummary.payoutPreferenceScheduledDate));
+    setScheduleDraft(
+      buildDefaultScheduledDate(payoutSummary.payoutPreferenceScheduledDate),
+    );
   }, [payoutSummary, pendingPreferenceMode]);
 
   if (
@@ -208,7 +236,8 @@ export default function ProfilePaymentsScreen() {
 
   const rows = paymentRows ?? [];
   const role = currentUser.role as "studio" | "instructor";
-  const isDetailLoading = selectedPaymentId !== null && selectedPaymentDetail === undefined;
+  const isDetailLoading =
+    selectedPaymentId !== null && selectedPaymentDetail === undefined;
   const isManualPayoutMode = payoutSummary?.payoutReleaseMode !== "automatic";
   const isIdentityVerified = payoutSummary?.isIdentityVerified ?? false;
   const savedPreferenceMode =
@@ -245,7 +274,11 @@ export default function ProfilePaymentsScreen() {
         );
       }
     } catch (error) {
-      setWithdrawError(error instanceof Error ? error.message : t("profile.payments.withdrawalFailed"));
+      setWithdrawError(
+        error instanceof Error
+          ? error.message
+          : t("profile.payments.withdrawalFailed"),
+      );
     } finally {
       setWithdrawBusy(false);
     }
@@ -281,7 +314,10 @@ export default function ProfilePaymentsScreen() {
         cancelUrl: beneficiaryCancelUrl,
       });
       setActiveOnboardingId(session.onboardingId);
-      const authResult = await WebBrowser.openAuthSessionAsync(session.redirectUrl, appReturnUrl);
+      const authResult = await WebBrowser.openAuthSessionAsync(
+        session.redirectUrl,
+        appReturnUrl,
+      );
       if (authResult.type === "success") {
         const resultUrl = authResult.url ? new URL(authResult.url) : null;
         const result = resultUrl?.searchParams.get("result") ?? "complete";
@@ -292,7 +328,10 @@ export default function ProfilePaymentsScreen() {
           setDestinationInfo(t("profile.payments.finalizingTitle"));
           setIsFinalizingOnboarding(true);
         }
-      } else if (authResult.type === "dismiss" || authResult.type === "cancel") {
+      } else if (
+        authResult.type === "dismiss" ||
+        authResult.type === "cancel"
+      ) {
         setActiveOnboardingId(null);
         setDestinationInfo(t("profile.payments.closed"));
       } else {
@@ -300,7 +339,11 @@ export default function ProfilePaymentsScreen() {
       }
     } catch (error) {
       setActiveOnboardingId(null);
-      setDestinationError(error instanceof Error ? error.message : t("profile.payments.openFailed"));
+      setDestinationError(
+        error instanceof Error
+          ? error.message
+          : t("profile.payments.openFailed"),
+      );
     } finally {
       setOnboardingBusy(false);
     }
@@ -335,11 +378,15 @@ export default function ProfilePaymentsScreen() {
             : t("profile.payments.preferenceSavedImmediate"),
       );
       if (Platform.OS === "ios") {
-        void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        void Haptics.notificationAsync(
+          Haptics.NotificationFeedbackType.Success,
+        );
       }
     } catch (error) {
       setPreferenceError(
-        error instanceof Error ? error.message : t("profile.payments.preferenceSaveFailed"),
+        error instanceof Error
+          ? error.message
+          : t("profile.payments.preferenceSaveFailed"),
       );
     } finally {
       setPreferenceBusy(false);
@@ -351,7 +398,9 @@ export default function ProfilePaymentsScreen() {
     setPreferenceInfo(null);
     if (mode === "scheduled_date") {
       setPendingPreferenceMode(mode);
-      setScheduleDraft(buildDefaultScheduledDate(payoutSummary?.payoutPreferenceScheduledDate));
+      setScheduleDraft(
+        buildDefaultScheduledDate(payoutSummary?.payoutPreferenceScheduledDate),
+      );
       setShowSchedulePicker(true);
       return;
     }
@@ -366,7 +415,11 @@ export default function ProfilePaymentsScreen() {
       <TabScreenScrollView
         routeKey="instructor/profile"
         style={{ flex: 1, backgroundColor: palette.appBg }}
-        contentContainerStyle={{ flexGrow: 1, padding: BrandSpacing.lg, justifyContent: "center" }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          padding: BrandSpacing.lg,
+          justifyContent: "center",
+        }}
       >
         <View
           style={{
@@ -378,8 +431,13 @@ export default function ProfilePaymentsScreen() {
             alignItems: "center",
           }}
         >
-          <ThemedText type="title">{t("profile.payments.finalizingTitle")}</ThemedText>
-          <ThemedText type="caption" style={{ color: palette.textMuted, textAlign: "center" }}>
+          <ThemedText type="title">
+            {t("profile.payments.finalizingTitle")}
+          </ThemedText>
+          <ThemedText
+            type="caption"
+            style={{ color: palette.textMuted, textAlign: "center" }}
+          >
             {t("profile.payments.finalizingBody")}
           </ThemedText>
         </View>
@@ -392,7 +450,11 @@ export default function ProfilePaymentsScreen() {
       <TabScreenScrollView
         routeKey="instructor/profile"
         style={{ flex: 1, backgroundColor: palette.appBg }}
-        contentContainerStyle={{ flexGrow: 1, padding: BrandSpacing.lg, justifyContent: "center" }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          padding: BrandSpacing.lg,
+          justifyContent: "center",
+        }}
       >
         <View
           style={{
@@ -405,8 +467,13 @@ export default function ProfilePaymentsScreen() {
           }}
         >
           <KitSuccessBurst iconName="building.columns.fill" />
-          <ThemedText type="title">{t("profile.payments.successTitle")}</ThemedText>
-          <ThemedText type="caption" style={{ color: palette.textMuted, textAlign: "center" }}>
+          <ThemedText type="title">
+            {t("profile.payments.successTitle")}
+          </ThemedText>
+          <ThemedText
+            type="caption"
+            style={{ color: palette.textMuted, textAlign: "center" }}
+          >
             {t("profile.payments.successBody")}
           </ThemedText>
         </View>
@@ -435,7 +502,9 @@ export default function ProfilePaymentsScreen() {
           <ThemedText
             type="micro"
             style={{
-              color: payoutSummary?.hasVerifiedDestination ? palette.success : palette.warning,
+              color: payoutSummary?.hasVerifiedDestination
+                ? palette.success
+                : palette.warning,
               fontWeight: "700",
             }}
           >
@@ -451,7 +520,9 @@ export default function ProfilePaymentsScreen() {
             paddingVertical: 4,
             borderRadius: 999,
             marginTop: 8,
-            backgroundColor: isIdentityVerified ? palette.successSubtle : palette.warningSubtle,
+            backgroundColor: isIdentityVerified
+              ? palette.successSubtle
+              : palette.warningSubtle,
           }}
         >
           <ThemedText
@@ -461,7 +532,9 @@ export default function ProfilePaymentsScreen() {
               fontWeight: "700",
             }}
           >
-            {isIdentityVerified ? t("profile.payments.kycVerified") : t("profile.payments.kycRequired")}
+            {isIdentityVerified
+              ? t("profile.payments.kycVerified")
+              : t("profile.payments.kycRequired")}
           </ThemedText>
         </View>
         {!isIdentityVerified ? (
@@ -469,18 +542,20 @@ export default function ProfilePaymentsScreen() {
             <ThemedText type="caption" style={{ color: palette.textMuted }}>
               {t("profile.payments.kycRequiredHint")}
             </ThemedText>
-            <KitPressable
+            <Pressable
               accessibilityRole="button"
               accessibilityLabel={t("profile.setup.verifyIdentity")}
-              haptic="impact"
-              pressedOpacity={0.9}
-              onPress={() => router.push(INSTRUCTOR_IDENTITY_VERIFICATION_ROUTE as Href)}
+              onPress={() =>
+                router.push(INSTRUCTOR_IDENTITY_VERIFICATION_ROUTE as Href)
+              }
               style={({ pressed }) => ({
                 paddingHorizontal: 14,
                 paddingVertical: 10,
                 borderRadius: 999,
                 borderCurve: "continuous",
-                backgroundColor: pressed ? palette.surfaceAlt : palette.primarySubtle,
+                backgroundColor: pressed
+                  ? palette.surfaceAlt
+                  : palette.primarySubtle,
                 borderWidth: 1,
                 borderColor: palette.primary as string,
               })}
@@ -488,17 +563,26 @@ export default function ProfilePaymentsScreen() {
               <ThemedText type="bodyStrong" style={{ color: palette.primary }}>
                 {t("profile.setup.verifyIdentity")}
               </ThemedText>
-            </KitPressable>
+            </Pressable>
           </View>
         ) : null}
-        {!payoutSummary?.hasVerifiedDestination && payoutSummary?.onboardingStatus === "pending" ? (
-          <ThemedText type="caption" style={{ color: palette.textMuted, marginTop: 6 }}>
+        {!payoutSummary?.hasVerifiedDestination &&
+        payoutSummary?.onboardingStatus === "pending" ? (
+          <ThemedText
+            type="caption"
+            style={{ color: palette.textMuted, marginTop: 6 }}
+          >
             {t("profile.payments.onboardingPending")}
           </ThemedText>
         ) : null}
-        {!payoutSummary?.hasVerifiedDestination && payoutSummary?.onboardingStatus === "failed" ? (
-          <ThemedText type="caption" style={{ color: palette.danger, marginTop: 6 }}>
-            {payoutSummary?.onboardingLastError ?? t("profile.payments.onboardingFailed")}
+        {!payoutSummary?.hasVerifiedDestination &&
+        payoutSummary?.onboardingStatus === "failed" ? (
+          <ThemedText
+            type="caption"
+            style={{ color: palette.danger, marginTop: 6 }}
+          >
+            {payoutSummary?.onboardingLastError ??
+              t("profile.payments.onboardingFailed")}
           </ThemedText>
         ) : null}
       </View>
@@ -564,20 +648,20 @@ export default function ProfilePaymentsScreen() {
                 borderRadius: 999,
               }}
             >
-              <ThemedText type="micro" style={{ color: "#FFF", fontWeight: "700" }}>
+              <ThemedText
+                type="micro"
+                style={{ color: "#FFF", fontWeight: "700" }}
+              >
                 {payoutSummary?.currency ?? "ILS"}
               </ThemedText>
             </View>
           </View>
 
           <View style={{ flexDirection: "row", gap: 12 }}>
-            <KitPressable
+            <Pressable
               accessibilityRole="button"
               accessibilityLabel={t("profile.payments.withdrawToBank")}
-              haptic="impact"
-              pressedOpacity={0.96}
-              pressStyle={{ transform: [{ scale: 0.985 }] }}
-              style={{
+              style={({ pressed }) => ({
                 flex: 1,
                 backgroundColor:
                   !isManualPayoutMode ||
@@ -596,7 +680,8 @@ export default function ProfilePaymentsScreen() {
                 justifyContent: "center",
                 gap: 8,
                 overflow: "hidden",
-              }}
+                transform: [{ scale: pressed ? 0.985 : 1 }],
+              })}
               onPress={() => {
                 confirmWithdrawToBank();
               }}
@@ -609,20 +694,21 @@ export default function ProfilePaymentsScreen() {
               }
             >
               <IconSymbol name="arrow.down" size={18} color="#FFF" />
-              <ThemedText type="bodyStrong" style={{ color: "#FFF", fontSize: 16 }}>
+              <ThemedText
+                type="bodyStrong"
+                style={{ color: "#FFF", fontSize: 16 }}
+              >
                 {t("profile.payments.withdraw")}
               </ThemedText>
-            </KitPressable>
+            </Pressable>
 
-            <KitPressable
+            <Pressable
               accessibilityRole="button"
               accessibilityLabel={
                 payoutSummary?.hasVerifiedDestination
                   ? t("profile.payments.manageBank")
                   : t("profile.payments.connectBank")
               }
-              pressedOpacity={0.96}
-              pressStyle={{ transform: [{ scale: 0.985 }] }}
               style={({ pressed }) => ({
                 flex: 1,
                 backgroundColor: payoutSummary?.hasVerifiedDestination
@@ -645,6 +731,7 @@ export default function ProfilePaymentsScreen() {
                 borderColor: payoutSummary?.hasVerifiedDestination
                   ? "rgba(255,255,255,0.18)"
                   : "rgba(255,255,255,0.22)",
+                transform: [{ scale: pressed ? 0.985 : 1 }],
               })}
               onPress={() => {
                 void startHostedBankOnboarding();
@@ -652,23 +739,37 @@ export default function ProfilePaymentsScreen() {
               disabled={onboardingBusy || !isIdentityVerified}
             >
               <IconSymbol name="building.columns.fill" size={18} color="#FFF" />
-              <ThemedText type="bodyStrong" style={{ color: "#FFF", fontSize: 16 }}>
+              <ThemedText
+                type="bodyStrong"
+                style={{ color: "#FFF", fontSize: 16 }}
+              >
                 {payoutSummary?.hasVerifiedDestination
                   ? t("profile.payments.manageBank")
                   : t("profile.payments.connectBank")}
               </ThemedText>
-            </KitPressable>
+            </Pressable>
           </View>
         </View>
 
         {withdrawError || destinationError ? (
           <ThemedText
-            style={{ color: palette.danger, marginTop: 12, textAlign: "center", fontWeight: "500" }}
+            style={{
+              color: palette.danger,
+              marginTop: 12,
+              textAlign: "center",
+              fontWeight: "500",
+            }}
           >
             {withdrawError || destinationError}
           </ThemedText>
         ) : withdrawInfo || destinationInfo ? (
-          <ThemedText style={{ color: palette.textMuted, marginTop: 12, textAlign: "center" }}>
+          <ThemedText
+            style={{
+              color: palette.textMuted,
+              marginTop: 12,
+              textAlign: "center",
+            }}
+          >
             {withdrawInfo || destinationInfo}
           </ThemedText>
         ) : null}
@@ -685,7 +786,9 @@ export default function ProfilePaymentsScreen() {
           }}
         >
           <View style={{ gap: 6 }}>
-            <ThemedText type="title">{t("profile.payments.preferenceTitle")}</ThemedText>
+            <ThemedText type="title">
+              {t("profile.payments.preferenceTitle")}
+            </ThemedText>
             <ThemedText type="caption" style={{ color: palette.textMuted }}>
               {t("profile.payments.preferenceSubtitle")}
             </ThemedText>
@@ -720,10 +823,9 @@ export default function ProfilePaymentsScreen() {
 
           {effectivePreferenceMode === "scheduled_date" ? (
             <View style={{ gap: 12 }}>
-              <KitPressable
+              <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={t("profile.payments.preferenceChooseDate")}
-                pressedOpacity={0.95}
                 onPress={() => setShowSchedulePicker((value) => !value)}
                 style={({ pressed }) => ({
                   borderRadius: 18,
@@ -740,7 +842,7 @@ export default function ProfilePaymentsScreen() {
                   {t("profile.payments.preferenceScheduleAt")}
                 </ThemedText>
                 <ThemedText type="bodyStrong">{scheduledAtLabel}</ThemedText>
-              </KitPressable>
+              </Pressable>
 
               {showSchedulePicker ? (
                 <View
@@ -770,7 +872,7 @@ export default function ProfilePaymentsScreen() {
                     }}
                   />
                   {Platform.OS === "ios" ? (
-                    <KitPressable
+                    <Pressable
                       accessibilityRole="button"
                       accessibilityLabel={t("common.done")}
                       onPress={() => setShowSchedulePicker(false)}
@@ -780,26 +882,33 @@ export default function ProfilePaymentsScreen() {
                         paddingVertical: 10,
                         borderRadius: 999,
                         borderCurve: "continuous",
-                        backgroundColor: pressed ? palette.surface : palette.primarySubtle,
+                        backgroundColor: pressed
+                          ? palette.surface
+                          : palette.primarySubtle,
                       })}
                     >
-                      <ThemedText type="bodyStrong" style={{ color: palette.primary }}>
+                      <ThemedText
+                        type="bodyStrong"
+                        style={{ color: palette.primary }}
+                      >
                         {t("common.done")}
                       </ThemedText>
-                    </KitPressable>
+                    </Pressable>
                   ) : null}
                 </View>
               ) : null}
 
               <View style={{ flexDirection: "row", gap: 12 }}>
-                <KitPressable
+                <Pressable
                   accessibilityRole="button"
                   accessibilityLabel={t("common.cancel")}
                   onPress={() => {
                     setPendingPreferenceMode(null);
                     setShowSchedulePicker(false);
                     setScheduleDraft(
-                      buildDefaultScheduledDate(payoutSummary?.payoutPreferenceScheduledDate),
+                      buildDefaultScheduledDate(
+                        payoutSummary?.payoutPreferenceScheduledDate,
+                      ),
                     );
                   }}
                   style={({ pressed }) => ({
@@ -814,13 +923,20 @@ export default function ProfilePaymentsScreen() {
                     backgroundColor: pressed ? palette.surface : palette.appBg,
                   })}
                 >
-                  <ThemedText type="bodyStrong">{t("common.cancel")}</ThemedText>
-                </KitPressable>
-                <KitPressable
+                  <ThemedText type="bodyStrong">
+                    {t("common.cancel")}
+                  </ThemedText>
+                </Pressable>
+                <Pressable
                   accessibilityRole="button"
-                  accessibilityLabel={t("profile.payments.preferenceSaveSchedule")}
+                  accessibilityLabel={t(
+                    "profile.payments.preferenceSaveSchedule",
+                  )}
                   onPress={() => {
-                    void savePayoutPreference("scheduled_date", scheduleDraft.getTime());
+                    void savePayoutPreference(
+                      "scheduled_date",
+                      scheduleDraft.getTime(),
+                    );
                   }}
                   disabled={preferenceBusy}
                   style={({ pressed }) => ({
@@ -835,12 +951,15 @@ export default function ProfilePaymentsScreen() {
                     transform: [{ scale: pressed ? 0.985 : 1 }],
                   })}
                 >
-                  <ThemedText type="bodyStrong" style={{ color: palette.onPrimary as string }}>
+                  <ThemedText
+                    type="bodyStrong"
+                    style={{ color: palette.onPrimary as string }}
+                  >
                     {preferenceBusy
                       ? t("profile.payments.preferenceSaving")
                       : t("profile.payments.preferenceSaveSchedule")}
                   </ThemedText>
-                </KitPressable>
+                </Pressable>
               </View>
             </View>
           ) : null}
@@ -858,7 +977,13 @@ export default function ProfilePaymentsScreen() {
       </View>
 
       {/* Stats Row */}
-      <View style={{ flexDirection: "row", paddingHorizontal: BrandSpacing.md, gap: 12 }}>
+      <View
+        style={{
+          flexDirection: "row",
+          paddingHorizontal: BrandSpacing.md,
+          gap: 12,
+        }}
+      >
         <View
           style={{
             flex: 1,
@@ -868,20 +993,34 @@ export default function ProfilePaymentsScreen() {
             borderCurve: "continuous",
           }}
         >
-          <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 8 }}>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              marginBottom: 8,
+            }}
+          >
             <View
               style={{
                 width: 8,
                 height: 8,
                 borderRadius: 4,
-                backgroundColor: palette.warning as import("react-native").ColorValue,
+                backgroundColor:
+                  palette.warning as import("react-native").ColorValue,
               }}
             />
-            <ThemedText type="caption" style={{ color: palette.textMuted, fontWeight: "600" }}>
+            <ThemedText
+              type="caption"
+              style={{ color: palette.textMuted, fontWeight: "600" }}
+            >
               {t("profile.payments.pending")}
             </ThemedText>
           </View>
-          <ThemedText type="title" style={{ fontSize: 22, fontVariant: ["tabular-nums"] }}>
+          <ThemedText
+            type="title"
+            style={{ fontSize: 22, fontVariant: ["tabular-nums"] }}
+          >
             {formatAgorotCurrency(
               payoutSummary?.pendingAmountAgorot ?? 0,
               locale,
@@ -898,20 +1037,34 @@ export default function ProfilePaymentsScreen() {
             borderCurve: "continuous",
           }}
         >
-          <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 8 }}>
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 6,
+              marginBottom: 8,
+            }}
+          >
             <View
               style={{
                 width: 8,
                 height: 8,
                 borderRadius: 4,
-                backgroundColor: palette.success as import("react-native").ColorValue,
+                backgroundColor:
+                  palette.success as import("react-native").ColorValue,
               }}
             />
-            <ThemedText type="caption" style={{ color: palette.textMuted, fontWeight: "600" }}>
+            <ThemedText
+              type="caption"
+              style={{ color: palette.textMuted, fontWeight: "600" }}
+            >
               {t("profile.payments.paid")}
             </ThemedText>
           </View>
-          <ThemedText type="title" style={{ fontSize: 22, fontVariant: ["tabular-nums"] }}>
+          <ThemedText
+            type="title"
+            style={{ fontSize: 22, fontVariant: ["tabular-nums"] }}
+          >
             {formatAgorotCurrency(
               payoutSummary?.paidAmountAgorot ?? 0,
               locale,
@@ -922,27 +1075,38 @@ export default function ProfilePaymentsScreen() {
       </View>
 
       {selectedPaymentId ? (
-        <View style={{ paddingHorizontal: BrandSpacing.md, gap: 12, marginTop: 8 }}>
+        <View
+          style={{ paddingHorizontal: BrandSpacing.md, gap: 12, marginTop: 8 }}
+        >
           <View
-            style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
           >
-            <ThemedText type="title">{t("profile.payments.receipt")}</ThemedText>
-            <KitPressable
+            <ThemedText type="title">
+              {t("profile.payments.receipt")}
+            </ThemedText>
+            <Pressable
               accessibilityRole="button"
               accessibilityLabel={t("profile.payments.close")}
               onPress={() => setSelectedPaymentId(null)}
-              pressedOpacity={0.94}
-              style={{
+              style={({ pressed }) => ({
                 backgroundColor: palette.surfaceAlt,
                 paddingHorizontal: 12,
                 paddingVertical: 6,
                 borderRadius: 999,
-              }}
+                opacity: pressed ? 0.84 : 1,
+              })}
             >
-              <ThemedText type="caption" style={{ color: palette.text, fontWeight: "600" }}>
+              <ThemedText
+                type="caption"
+                style={{ color: palette.text, fontWeight: "600" }}
+              >
                 {t("profile.payments.close")}
               </ThemedText>
-            </KitPressable>
+            </Pressable>
           </View>
           {isDetailLoading ? (
             <View
@@ -1006,40 +1170,67 @@ export default function ProfilePaymentsScreen() {
                     color={palette.success as import("react-native").ColorValue}
                   />
                 </View>
-                <ThemedText type="title" style={{ fontSize: 32, fontVariant: ["tabular-nums"] }}>
+                <ThemedText
+                  type="title"
+                  style={{ fontSize: 32, fontVariant: ["tabular-nums"] }}
+                >
                   {formatAgorotCurrency(
                     role === "studio"
                       ? selectedPaymentDetail.payment.studioChargeAmountAgorot
-                      : selectedPaymentDetail.payment.instructorBaseAmountAgorot,
+                      : selectedPaymentDetail.payment
+                          .instructorBaseAmountAgorot,
                     locale,
                     selectedPaymentDetail.payment.currency,
                   )}
                 </ThemedText>
                 <ThemedText type="caption" style={{ color: palette.textMuted }}>
-                  {formatDateTime(selectedPaymentDetail.payment.createdAt, locale)}
+                  {formatDateTime(
+                    selectedPaymentDetail.payment.createdAt,
+                    locale,
+                  )}
                 </ThemedText>
               </View>
               <View style={{ padding: 20, gap: 16 }}>
-                <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-                  <ThemedText type="caption" style={{ color: palette.textMuted }}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <ThemedText
+                    type="caption"
+                    style={{ color: palette.textMuted }}
+                  >
                     {t("profile.payments.status")}
                   </ThemedText>
                   <ThemedText type="bodyStrong">
-                    {getPaymentStatusLabel(selectedPaymentDetail.payment.status)}
+                    {getPaymentStatusLabel(
+                      selectedPaymentDetail.payment.status,
+                    )}
                   </ThemedText>
                 </View>
-                <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-                  <ThemedText type="caption" style={{ color: palette.textMuted }}>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <ThemedText
+                    type="caption"
+                    style={{ color: palette.textMuted }}
+                  >
                     {t("profile.payments.payout")}
                   </ThemedText>
                   <ThemedText type="bodyStrong">
                     {selectedPaymentDetail.payout
-                      ? getPayoutStatusLabel(selectedPaymentDetail.payout.status)
+                      ? getPayoutStatusLabel(
+                          selectedPaymentDetail.payout.status,
+                        )
                       : t("profile.payments.pending")}
                   </ThemedText>
                 </View>
                 {selectedPaymentDetail.invoice?.externalInvoiceUrl ? (
-                  <KitPressable
+                  <Pressable
                     accessibilityRole="button"
                     accessibilityLabel={t("profile.payments.downloadInvoice")}
                     onPress={() => {
@@ -1047,19 +1238,26 @@ export default function ProfilePaymentsScreen() {
                         selectedPaymentDetail.invoice!.externalInvoiceUrl!,
                       );
                     }}
-                    pressedOpacity={0.94}
-                    style={{
+                    style={({ pressed }) => ({
                       flexDirection: "row",
                       alignItems: "center",
                       justifyContent: "space-between",
                       paddingVertical: 8,
-                    }}
+                      opacity: pressed ? 0.84 : 1,
+                    })}
+                  >
+                    <ThemedText
+                      type="bodyStrong"
+                      style={{ color: palette.primary }}
                     >
-                    <ThemedText type="bodyStrong" style={{ color: palette.primary }}>
                       {t("profile.payments.downloadInvoice")}
                     </ThemedText>
-                    <IconSymbol name="arrow.up.right" size={16} color={palette.primary} />
-                  </KitPressable>
+                    <IconSymbol
+                      name="arrow.up.right"
+                      size={16}
+                      color={palette.primary}
+                    />
+                  </Pressable>
                 ) : null}
               </View>
             </View>


### PR DESCRIPTION
## Summary
- remove KitPressable usage from the instructor payments screen
- simplify payout, bank, schedule, and receipt actions to native Pressable controls
- update the brutal audit log with the payments slice

## Validation
- bun run typecheck