### PR TITLE
UI Cut 16: simplify onboarding chrome

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -574,6 +574,12 @@ Replace with consequence and momentum:
 - removed alert theater, extra summary cards, and redundant explanatory copy from the desktop frame
 - tightened the navigation rail and top workspace bar so the page gets to real content faster
 
+### Slice 16
+
+- removed repeated caption chrome from onboarding cards so each step leads with the real form action instead of duplicate labels
+- took push permission out of the instructor detail step and moved it behind the core onboarding save path
+- kept the onboarding structure intact while reducing first-run ceremony and making the main flow faster to finish
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/app/onboarding.tsx
+++ b/src/app/onboarding.tsx
@@ -76,23 +76,6 @@ function StepBadge({
   );
 }
 
-function SectionCaption({
-  label,
-  palette,
-}: {
-  label: string;
-  palette: ReturnType<typeof useBrand>;
-}) {
-  return (
-    <ThemedText
-      type="micro"
-      style={{ color: palette.textMuted, letterSpacing: 0.2 }}
-    >
-      {label}
-    </ThemedText>
-  );
-}
-
 export default function OnboardingScreen() {
   const router = useRouter();
   const { t, i18n } = useTranslation();
@@ -624,11 +607,6 @@ export default function OnboardingScreen() {
       <ThemedText type="subtitle">
         {t("onboarding.instructorDetailsTitle")}
       </ThemedText>
-
-      <SectionCaption
-        label={t("onboarding.instructorDetailsTitle")}
-        palette={palette}
-      />
       <KitTextField
         label={t("onboarding.displayName")}
         value={displayName}
@@ -653,7 +631,6 @@ export default function OnboardingScreen() {
       />
 
       <View style={styles.sectionBlock}>
-        <SectionCaption label={t("onboarding.sportsTitle")} palette={palette} />
         <ThemedText type="defaultSemiBold">
           {t("onboarding.sportsTitle")}
         </ThemedText>
@@ -670,10 +647,9 @@ export default function OnboardingScreen() {
       </View>
 
       <View style={styles.sectionBlock}>
-        <SectionCaption
-          label={t("profile.settings.location.title")}
-          palette={palette}
-        />
+        <ThemedText type="defaultSemiBold">
+          {t("profile.settings.location.title")}
+        </ThemedText>
         <AddressAutocomplete
           value={instructorAddress}
           onChangeText={(value) => {
@@ -731,25 +707,6 @@ export default function OnboardingScreen() {
           })}
         </View>
       </View>
-
-      <View style={styles.sectionBlock}>
-        <ActionButton
-          disabled={isRequestingPush}
-          label={
-            isRequestingPush
-              ? t("onboarding.push.requesting")
-              : pushToken
-                ? t("onboarding.push.enabled")
-                : t("onboarding.push.requestPermission")
-          }
-          palette={palette}
-          tone={pushToken ? "secondary" : "primary"}
-          fullWidth
-          onPress={() => {
-            void requestPushPermission();
-          }}
-        />
-      </View>
     </KitSurface>
   );
 
@@ -758,11 +715,6 @@ export default function OnboardingScreen() {
       <ThemedText type="subtitle">
         {t("onboarding.studioDetailsTitle")}
       </ThemedText>
-
-      <SectionCaption
-        label={t("onboarding.studioDetailsTitle")}
-        palette={palette}
-      />
       <KitTextField
         label={t("onboarding.studioName")}
         value={studioName}
@@ -852,10 +804,6 @@ export default function OnboardingScreen() {
 
       {step === 0 ? (
         <KitSurface tone="elevated" style={styles.roleCard}>
-          <SectionCaption
-            label={t("onboarding.rolePrompt")}
-            palette={palette}
-          />
           <ThemedText type="defaultSemiBold">
             {t("onboarding.rolePrompt")}
           </ThemedText>
@@ -915,16 +863,29 @@ export default function OnboardingScreen() {
         </View>
       ) : step === 2 && role === "instructor" ? (
         <KitSurface tone="elevated" style={styles.verifyCard}>
-          <SectionCaption
-            label={t("onboarding.verification.title")}
-            palette={palette}
-          />
           <ThemedText type="subtitle">
             {t("onboarding.verification.subtitle")}
           </ThemedText>
           <ThemedText style={{ color: palette.textMuted }}>
             {t("onboarding.verification.body")}
           </ThemedText>
+
+          {!pushToken ? (
+            <ActionButton
+              disabled={isRequestingPush}
+              label={
+                isRequestingPush
+                  ? t("onboarding.push.requesting")
+                  : t("onboarding.push.requestPermission")
+              }
+              palette={palette}
+              tone="secondary"
+              fullWidth
+              onPress={() => {
+                void requestPushPermission();
+              }}
+            />
+          ) : null}
 
           <View style={styles.verifyActions}>
             <ActionButton


### PR DESCRIPTION
## Summary
- remove repeated caption chrome from onboarding cards
- move push permission out of the main instructor detail step and behind the core onboarding save path
- update the brutal audit log with the onboarding slice

## Validation
- bun run typecheck