### PR TITLE
UI Redesign 02: normalize instructor location

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -586,6 +586,12 @@ Replace with consequence and momentum:
 - replaced soft dashboard copy with stronger signal tiles, direct action rails, and tighter queue language
 - kept the redesign on shared semantic tokens only so the new home pass does not introduce another color or styling pocket
 
+### Slice 18
+
+- rebuilt the instructor location page from a generic settings form into a status-first command surface
+- removed the remaining `KitList` and `KitSwitchRow` shell in favor of shared profile cards, one address lane, one zone lane, and a fixed save rail
+- normalized the page onto semantic palette tokens only while tightening the zone-resolution feedback and error messaging
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/location.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/location.tsx
@@ -1,20 +1,31 @@
 import { useMutation, useQuery } from "convex/react";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, Switch, Text, View } from "react-native";
+
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
-import { ThemedText } from "@/components/themed-text";
+import {
+  ProfileSectionCard,
+  ProfileSectionHeader,
+} from "@/components/profile/profile-settings-sections";
+import { IconSymbol } from "@/components/ui/icon-symbol";
 import { ActionButton } from "@/components/ui/action-button";
 import { AddressAutocomplete } from "@/components/ui/address-autocomplete";
-import { KitList, KitListItem, KitSwitchRow } from "@/components/ui/kit";
-import { BrandSpacing } from "@/constants/brand";
+import {
+  BrandRadius,
+  BrandSpacing,
+  BrandType,
+  type BrandPalette,
+} from "@/constants/brand";
 import { useUser } from "@/contexts/user-context";
 import { api } from "@/convex/_generated/api";
+import { useAppInsets } from "@/hooks/use-app-insets";
 import { useBrand } from "@/hooks/use-brand";
 import { useLocationResolution } from "@/hooks/use-location-resolution";
 import { getLocationResolveErrorMessage } from "@/lib/location-error-message";
+import type { PlaceCoordinates } from "@/lib/google-places";
 import type { ResolvedLocation } from "@/lib/location-zone";
 
 let zoneLabelByIdPromise: Promise<
@@ -37,10 +48,75 @@ async function getZoneLabelById(
   return labelsByZoneId.get(zoneId)?.[language] ?? zoneId;
 }
 
+function formatCoordinateLabel(latitude?: number, longitude?: number) {
+  if (latitude === undefined || longitude === undefined) {
+    return null;
+  }
+
+  return `${latitude.toFixed(4)}, ${longitude.toFixed(4)}`;
+}
+
+function StatusSignal({
+  label,
+  value,
+  palette,
+  tone = "surface",
+}: {
+  label: string;
+  value: string;
+  palette: BrandPalette;
+  tone?: "surface" | "accent";
+}) {
+  const backgroundColor =
+    tone === "accent"
+      ? (palette.primarySubtle as string)
+      : (palette.surfaceElevated as string);
+  const labelColor =
+    tone === "accent"
+      ? (palette.primary as string)
+      : (palette.textMuted as string);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        minWidth: 0,
+        gap: 2,
+        borderRadius: BrandRadius.card - 6,
+        borderCurve: "continuous",
+        backgroundColor,
+        paddingHorizontal: 14,
+        paddingVertical: 12,
+      }}
+    >
+      <Text
+        style={{
+          ...BrandType.micro,
+          color: labelColor,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        numberOfLines={1}
+        style={{
+          ...BrandType.bodyStrong,
+          color: palette.text as string,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
 export default function LocationScreen() {
   const { t, i18n } = useTranslation();
   const palette = useBrand();
   const router = useRouter();
+  const { overlayBottom } = useAppInsets();
   const { currentUser } = useUser();
   const languageCode = (i18n.resolvedLanguage ?? "en") as "en" | "he";
 
@@ -49,6 +125,7 @@ export default function LocationScreen() {
     currentUser?.role === "instructor" ? {} : "skip",
   );
   const saveInstructor = useMutation(api.users.updateMyInstructorSettings);
+  const locationResolver = useLocationResolution();
 
   const [addressInput, setAddressInput] = useState("");
   const [latitude, setLatitude] = useState<number>();
@@ -61,11 +138,6 @@ export default function LocationScreen() {
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [seeded, setSeeded] = useState(false);
-  const screenStyle = useMemo(
-    () =>
-      StyleSheet.flatten([styles.screen, { backgroundColor: palette.appBg }]),
-    [palette.appBg],
-  );
 
   useEffect(() => {
     if (instructorSettings && !seeded) {
@@ -76,22 +148,29 @@ export default function LocationScreen() {
     }
   }, [instructorSettings, seeded]);
 
-  const locationResolver = useLocationResolution();
-
   useEffect(() => {
     if (!detectedZone) {
       setDetectedZoneLabel(null);
       return;
     }
+
     let cancelled = false;
     void getZoneLabelById(detectedZone, languageCode).then((label) => {
-      if (cancelled) return;
+      if (cancelled) {
+        return;
+      }
       setDetectedZoneLabel(label);
     });
+
     return () => {
       cancelled = true;
     };
   }, [detectedZone, languageCode]);
+
+  const clearDetectedZone = useCallback(() => {
+    setDetectedZone(null);
+    setIncludeDetectedZone(false);
+  }, []);
 
   const applyResolution = useCallback((resolved: ResolvedLocation) => {
     setAddressInput(resolved.address);
@@ -100,6 +179,64 @@ export default function LocationScreen() {
     setErrorMessage(null);
   }, []);
 
+  const resolveZoneFromCoordinates = useCallback(
+    async (coords: { latitude: number; longitude: number }) => {
+      const result = await locationResolver.resolveFromCoordinates(coords);
+
+      if (!result.ok) {
+        clearDetectedZone();
+        setErrorMessage(
+          getLocationResolveErrorMessage({
+            code: result.error.code,
+            fallbackMessage: result.error.message,
+            fallbackKey: "locationResolveFailed",
+            translationPrefix: "profile.settings.errors",
+            t,
+          }),
+        );
+        return;
+      }
+
+      const zoneId = result.data.value.zoneId ?? null;
+      if (!zoneId) {
+        clearDetectedZone();
+        return;
+      }
+
+      setDetectedZone(zoneId);
+      setIncludeDetectedZone(true);
+      setErrorMessage(null);
+    },
+    [clearDetectedZone, locationResolver, t],
+  );
+
+  const handlePlaceSelected = useCallback(
+    (coords: PlaceCoordinates) => {
+      applyResolution({
+        address: coords.formattedAddress,
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+        zoneId: "",
+      });
+      void resolveZoneFromCoordinates({
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+      });
+    },
+    [applyResolution, resolveZoneFromCoordinates],
+  );
+
+  const handleAddressChange = useCallback(
+    (value: string) => {
+      setAddressInput(value);
+      setLatitude(undefined);
+      setLongitude(undefined);
+      clearDetectedZone();
+      setErrorMessage(null);
+    },
+    [clearDetectedZone],
+  );
+
   const resolveByGps = useCallback(async () => {
     const result = await locationResolver.resolveFromGps();
     if (!result.ok) {
@@ -107,19 +244,23 @@ export default function LocationScreen() {
         getLocationResolveErrorMessage({
           code: result.error.code,
           fallbackMessage: result.error.message,
-          fallbackKey: "errors.resolveFailed",
-          translationPrefix: "profile.settings.location",
+          fallbackKey: "locationResolveFailed",
+          translationPrefix: "profile.settings.errors",
           t,
         }),
       );
       return;
     }
+
     applyResolution(result.data.value);
     if (result.data.value.zoneId) {
       setDetectedZone(result.data.value.zoneId);
       setIncludeDetectedZone(true);
+      return;
     }
-  }, [locationResolver, applyResolution, t]);
+
+    clearDetectedZone();
+  }, [applyResolution, clearDetectedZone, locationResolver, t]);
 
   if (instructorSettings === undefined) {
     return <LoadingScreen label={t("profile.settings.loading")} />;
@@ -128,9 +269,56 @@ export default function LocationScreen() {
     return <LoadingScreen label={t("profile.settings.unavailable")} />;
   }
 
+  const trimmedAddressInput = addressInput.trim();
+  const initialAddress = instructorSettings.address?.trim() ?? "";
+  const coordinateLabel = formatCoordinateLabel(latitude, longitude);
+  const hasAddress = trimmedAddressInput.length > 0;
+  const hasDetectedZone = Boolean(detectedZone);
+  const hasLocationChanges =
+    trimmedAddressInput !== initialAddress ||
+    latitude !== instructorSettings.latitude ||
+    longitude !== instructorSettings.longitude;
+  const hasZoneAssignment = hasDetectedZone && includeDetectedZone;
+  const hasChanges = hasLocationChanges || hasZoneAssignment;
+
+  const heroTitle = hasDetectedZone
+    ? t("profile.location.heroReady", {
+        defaultValue: "Your base is locked in",
+      })
+    : hasAddress
+      ? t("profile.location.heroPending", {
+          defaultValue: "Finish the zone and save it",
+        })
+      : t("profile.location.heroMissing", {
+          defaultValue: "Set the base you teach from",
+        });
+  const heroBody = hasDetectedZone
+    ? t("profile.location.heroReadyBody", {
+        defaultValue:
+          "Address, coordinates, and detected zone are aligned and ready to publish.",
+      })
+    : hasAddress
+      ? t("profile.location.heroPendingBody", {
+          defaultValue:
+            "You have an address draft. Resolve the zone, confirm it, and save to make it live.",
+        })
+      : t("profile.location.heroMissingBody", {
+          defaultValue:
+            "Add a base address or use GPS so studios see where you operate from.",
+        });
+  const zoneDisplayValue = detectedZone
+    ? detectedZoneLabel ?? detectedZone
+    : t("profile.settings.location.zoneNotDetected");
+
   const onSave = async () => {
+    if (!hasChanges) {
+      router.back();
+      return;
+    }
+
     setIsSaving(true);
     setErrorMessage(null);
+
     try {
       await saveInstructor({
         notificationsEnabled: instructorSettings.notificationsEnabled,
@@ -140,7 +328,7 @@ export default function LocationScreen() {
         ...(instructorSettings.hourlyRateExpectation !== undefined
           ? { hourlyRateExpectation: instructorSettings.hourlyRateExpectation }
           : {}),
-        ...(addressInput.trim() ? { address: addressInput.trim() } : {}),
+        ...(trimmedAddressInput ? { address: trimmedAddressInput } : {}),
         ...(latitude !== undefined ? { latitude } : {}),
         ...(longitude !== undefined ? { longitude } : {}),
         includeDetectedZone,
@@ -159,119 +347,338 @@ export default function LocationScreen() {
   };
 
   return (
-    <TabScreenScrollView
-      routeKey="instructor/profile"
-      style={screenStyle}
-      keyboardShouldPersistTaps="handled"
-    >
-      <KitList inset>
-        <KitListItem title={t("profile.settings.location.addressPlaceholder")}>
-          <View style={{ gap: 8, marginTop: 8 }}>
-            <AddressAutocomplete
-              value={addressInput}
-              onChangeText={(value) => {
-                setAddressInput(value);
-                setLatitude(undefined);
-                setLongitude(undefined);
-                setDetectedZone(null);
-                setIncludeDetectedZone(false);
-              }}
-              onPlaceSelected={(coords) => {
-                applyResolution({
-                  address: coords.formattedAddress,
-                  latitude: coords.latitude,
-                  longitude: coords.longitude,
-                  zoneId: "",
-                });
-                void locationResolver
-                  .resolveFromCoordinates({
-                    latitude: coords.latitude,
-                    longitude: coords.longitude,
-                  })
-                  .then((result) => {
-                    if (!result.ok || !result.data.value.zoneId) return;
-                    setDetectedZone(result.data.value.zoneId);
-                    setIncludeDetectedZone(true);
-                  });
-              }}
-              placeholder={t("profile.settings.location.addressPlaceholder")}
-              placeholderTextColor={palette.textMuted}
-              borderColor={palette.border}
-              textColor={palette.text}
-              backgroundColor={palette.appBg}
-              surfaceColor={palette.surface}
-              mutedTextColor={palette.textMuted}
-            />
-            <ActionButton
-              label={
-                locationResolver.isResolving
-                  ? t("profile.settings.location.resolvingGps")
-                  : t("profile.settings.location.useGps")
-              }
-              onPress={() => {
-                void resolveByGps();
-              }}
-              disabled={locationResolver.isResolving}
-              palette={palette}
-              tone="secondary"
-              fullWidth
-            />
-          </View>
-        </KitListItem>
-      </KitList>
-
-      {/* Zone badge */}
-      <View style={{ paddingHorizontal: 16, paddingTop: 12 }}>
+    <View style={[styles.screen, { backgroundColor: palette.appBg }]}>
+      <TabScreenScrollView
+        routeKey="instructor/profile"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{
+          paddingHorizontal: BrandSpacing.lg,
+          paddingTop: BrandSpacing.lg,
+          paddingBottom: 148,
+          gap: BrandSpacing.lg,
+        }}
+      >
         <View
           style={[
-            styles.locationBadge,
+            styles.heroCard,
             {
-              borderColor: detectedZone ? palette.primary : palette.border,
-              backgroundColor: detectedZone
-                ? palette.primarySubtle
-                : palette.appBg,
+              backgroundColor: palette.surfaceAlt as string,
+              borderColor: palette.border as string,
             },
           ]}
         >
-          <ThemedText
-            style={{
-              color: detectedZone ? palette.primary : palette.textMuted,
-            }}
-          >
-            {detectedZone
-              ? t("profile.settings.location.detectedZone", {
-                  zone: detectedZoneLabel ?? detectedZone,
-                })
-              : t("profile.settings.location.zoneNotDetected")}
-          </ThemedText>
-        </View>
-      </View>
+          <View style={styles.heroHeaderRow}>
+            <View style={styles.heroCopy}>
+              <Text
+                style={{
+                  ...BrandType.micro,
+                  color: palette.textMuted as string,
+                  letterSpacing: 0.8,
+                }}
+              >
+                {t("profile.settings.location.title").toUpperCase()}
+              </Text>
+              <Text
+                style={{
+                  ...BrandType.heading,
+                  color: palette.text as string,
+                }}
+              >
+                {heroTitle}
+              </Text>
+              <Text
+                style={{
+                  ...BrandType.body,
+                  color: palette.textMuted as string,
+                }}
+              >
+                {heroBody}
+              </Text>
+            </View>
+            <View
+              style={[
+                styles.heroIconWrap,
+                { backgroundColor: palette.primarySubtle as string },
+              ]}
+            >
+              <IconSymbol
+                name="mappin.and.ellipse"
+                size={22}
+                color={palette.primary as string}
+              />
+            </View>
+          </View>
 
-      {/* Include zone toggle */}
-      {detectedZone ? (
-        <View style={{ paddingTop: 8 }}>
-          <KitList inset>
-            <KitSwitchRow
-              title={t("profile.settings.location.includeDetectedZone")}
-              value={includeDetectedZone}
-              onValueChange={setIncludeDetectedZone}
+          <View style={styles.heroSignalsRow}>
+            <StatusSignal
+              label={t("profile.location.signalAddress", {
+                defaultValue: "Address",
+              })}
+              value={
+                hasAddress
+                  ? t("profile.location.signalAddressReady", {
+                      defaultValue: "Ready",
+                    })
+                  : t("profile.location.signalAddressMissing", {
+                      defaultValue: "Missing",
+                    })
+              }
+              palette={palette}
             />
-          </KitList>
+            <StatusSignal
+              label={t("profile.location.signalZone", {
+                defaultValue: "Zone",
+              })}
+              value={hasDetectedZone ? zoneDisplayValue : t("common.pending")}
+              palette={palette}
+              tone={hasDetectedZone ? "accent" : "surface"}
+            />
+          </View>
         </View>
-      ) : null}
 
-      {/* Error */}
-      {errorMessage ? (
-        <View style={{ paddingHorizontal: 16, paddingTop: 12 }}>
-          <ThemedText style={{ color: palette.danger }}>
-            {errorMessage}
-          </ThemedText>
+        <View style={{ gap: BrandSpacing.sm }}>
+          <ProfileSectionHeader
+            label={t("profile.location.commandLabel", {
+              defaultValue: "Command",
+            })}
+            description={t("profile.settings.location.instructorDescription")}
+            icon="mappin.and.ellipse"
+            palette={palette}
+            flush
+          />
+          <ProfileSectionCard palette={palette} style={{ marginHorizontal: 0 }}>
+            <View style={styles.sectionBody}>
+              <View style={{ gap: 4 }}>
+                <Text
+                  style={{
+                    ...BrandType.title,
+                    color: palette.text as string,
+                  }}
+                >
+                  {t("profile.location.addressTitle", {
+                    defaultValue: "Search your base address",
+                  })}
+                </Text>
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  {t("profile.location.addressBody", {
+                    defaultValue:
+                      "Type the address you teach from most often or let GPS pull it in instantly.",
+                  })}
+                </Text>
+              </View>
+
+              <AddressAutocomplete
+                value={addressInput}
+                onChangeText={handleAddressChange}
+                onPlaceSelected={handlePlaceSelected}
+                placeholder={t("profile.settings.location.addressPlaceholder")}
+                placeholderTextColor={palette.textMuted}
+                borderColor={palette.border}
+                textColor={palette.text}
+                backgroundColor={palette.surfaceElevated}
+                surfaceColor={palette.surfaceElevated}
+                mutedTextColor={palette.textMuted}
+              />
+
+              <ActionButton
+                label={
+                  locationResolver.isResolving
+                    ? t("profile.settings.location.resolvingGps")
+                    : t("profile.settings.location.useGps")
+                }
+                onPress={() => {
+                  void resolveByGps();
+                }}
+                disabled={locationResolver.isResolving}
+                palette={palette}
+                tone="secondary"
+                fullWidth
+              />
+
+              {coordinateLabel ? (
+                <View
+                  style={[
+                    styles.metaStrip,
+                    {
+                      borderColor: palette.border as string,
+                      backgroundColor: palette.surfaceElevated as string,
+                    },
+                  ]}
+                >
+                  <Text
+                    style={{
+                      ...BrandType.micro,
+                      color: palette.textMuted as string,
+                      letterSpacing: 0.6,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {t("profile.location.coordinatesLabel", {
+                      defaultValue: "Coordinates",
+                    })}
+                  </Text>
+                  <Text
+                    style={{
+                      ...BrandType.bodyMedium,
+                      color: palette.text as string,
+                    }}
+                  >
+                    {coordinateLabel}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          </ProfileSectionCard>
         </View>
-      ) : null}
 
-      {/* Actions */}
+        <View style={{ gap: BrandSpacing.sm }}>
+          <ProfileSectionHeader
+            label={t("profile.location.zoneLabel", {
+              defaultValue: "Zone state",
+            })}
+            description={t("profile.location.zoneDescription", {
+              defaultValue:
+                "Use the detected zone as your default operating zone when the address looks right.",
+            })}
+            icon="checkmark.circle.fill"
+            palette={palette}
+            flush
+          />
+          <ProfileSectionCard palette={palette} style={{ marginHorizontal: 0 }}>
+            <View style={styles.sectionBody}>
+              <View
+                style={[
+                  styles.zoneStateCard,
+                  {
+                    borderColor: hasDetectedZone
+                      ? (palette.primary as string)
+                      : (palette.border as string),
+                    backgroundColor: hasDetectedZone
+                      ? (palette.primarySubtle as string)
+                      : (palette.surfaceElevated as string),
+                  },
+                ]}
+              >
+                <Text
+                  style={{
+                    ...BrandType.micro,
+                    color: hasDetectedZone
+                      ? (palette.primary as string)
+                      : (palette.textMuted as string),
+                    letterSpacing: 0.6,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {hasDetectedZone
+                    ? t("profile.location.zoneDetectedLabel", {
+                        defaultValue: "Detected zone",
+                      })
+                    : t("profile.location.zoneWaitingLabel", {
+                        defaultValue: "Zone pending",
+                      })}
+                </Text>
+                <Text
+                  style={{
+                    ...BrandType.title,
+                    color: palette.text as string,
+                  }}
+                >
+                  {zoneDisplayValue}
+                </Text>
+                <Text
+                  style={{
+                    ...BrandType.caption,
+                    color: palette.textMuted as string,
+                  }}
+                >
+                  {hasDetectedZone
+                    ? t("profile.settings.location.includeDetectedZoneDescription")
+                    : t("profile.location.zonePendingBody", {
+                        defaultValue:
+                          "Search an address or use GPS to resolve the service zone automatically.",
+                      })}
+                </Text>
+              </View>
+
+              {hasDetectedZone ? (
+                <View
+                  style={[
+                    styles.toggleRow,
+                    {
+                      borderColor: palette.border as string,
+                      backgroundColor: palette.surfaceElevated as string,
+                    },
+                  ]}
+                >
+                  <View style={{ flex: 1, gap: 4, minWidth: 0 }}>
+                    <Text
+                      style={{
+                        ...BrandType.bodyStrong,
+                        color: palette.text as string,
+                      }}
+                    >
+                      {t("profile.settings.location.includeDetectedZone")}
+                    </Text>
+                    <Text
+                      style={{
+                        ...BrandType.caption,
+                        color: palette.textMuted as string,
+                      }}
+                    >
+                      {t("profile.settings.location.includeDetectedZoneDescription")}
+                    </Text>
+                  </View>
+                  <Switch
+                    value={includeDetectedZone}
+                    onValueChange={setIncludeDetectedZone}
+                    trackColor={{
+                      false: palette.borderStrong as string,
+                      true: palette.primary as string,
+                    }}
+                    thumbColor={palette.surfaceElevated as string}
+                    ios_backgroundColor={palette.borderStrong as string}
+                  />
+                </View>
+              ) : null}
+            </View>
+          </ProfileSectionCard>
+        </View>
+
+        {errorMessage ? (
+          <View
+            style={[
+              styles.errorCard,
+              {
+                borderColor: palette.danger as string,
+                backgroundColor: palette.dangerSubtle as string,
+              },
+            ]}
+          >
+            <Text
+              style={{
+                ...BrandType.bodyMedium,
+                color: palette.danger as string,
+              }}
+            >
+              {errorMessage}
+            </Text>
+          </View>
+        ) : null}
+      </TabScreenScrollView>
+
       <View
-        style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}
+        style={[
+          styles.actionRail,
+          {
+            bottom: overlayBottom,
+            backgroundColor: palette.appBg as string,
+          },
+        ]}
       >
         <ActionButton
           label={
@@ -282,7 +689,7 @@ export default function LocationScreen() {
           onPress={() => {
             void onSave();
           }}
-          disabled={isSaving}
+          disabled={!hasChanges || isSaving}
           palette={palette}
           fullWidth
         />
@@ -294,7 +701,7 @@ export default function LocationScreen() {
           fullWidth
         />
       </View>
-    </TabScreenScrollView>
+    </View>
   );
 }
 
@@ -302,13 +709,75 @@ const styles = StyleSheet.create({
   screen: {
     flex: 1,
   },
-  locationBadge: {
+  heroCard: {
+    gap: BrandSpacing.lg,
     borderWidth: 1,
-    borderRadius: 10,
+    borderRadius: BrandRadius.card,
     borderCurve: "continuous",
-    minHeight: 38,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    padding: BrandSpacing.xl,
+  },
+  heroHeaderRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: BrandSpacing.md,
+  },
+  heroCopy: {
+    flex: 1,
+    gap: 6,
+    minWidth: 0,
+  },
+  heroIconWrap: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    borderCurve: "continuous",
+    alignItems: "center",
     justifyContent: "center",
+  },
+  heroSignalsRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  sectionBody: {
+    padding: BrandSpacing.lg,
+    gap: BrandSpacing.md,
+  },
+  metaStrip: {
+    gap: 2,
+    borderWidth: 1,
+    borderRadius: BrandRadius.button,
+    borderCurve: "continuous",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  zoneStateCard: {
+    gap: 6,
+    borderWidth: 1,
+    borderRadius: BrandRadius.card - 4,
+    borderCurve: "continuous",
+    padding: BrandSpacing.lg,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: BrandSpacing.md,
+    borderWidth: 1,
+    borderRadius: BrandRadius.button,
+    borderCurve: "continuous",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  errorCard: {
+    borderWidth: 1,
+    borderRadius: BrandRadius.button,
+    borderCurve: "continuous",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  actionRail: {
+    position: "absolute",
+    left: BrandSpacing.lg,
+    right: BrandSpacing.lg,
+    gap: 10,
   },
 });


### PR DESCRIPTION
## Summary
- redesign the instructor location page into a status-first command surface
- remove the remaining KitList and KitSwitchRow shell from that route
- keep the page on semantic palette tokens while improving zone-resolution feedback

## Validation
- bun run typecheck