### PR TITLE
UI Redesign 03: normalize calendar settings

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -592,6 +592,12 @@ Replace with consequence and momentum:
 - removed the remaining `KitList` and `KitSwitchRow` shell in favor of shared profile cards, one address lane, one zone lane, and a fixed save rail
 - normalized the page onto semantic palette tokens only while tightening the zone-resolution feedback and error messaging
 
+### Slice 19
+
+- rebuilt the instructor calendar settings page into a provider-first operations surface instead of a segmented settings dump
+- removed the remaining `KitList`, `KitSegmentedToggle`, and `KitSwitchRow` shell from the route in favor of shared profile cards and direct provider actions
+- fixed the save flow so choosing `No sync` persists cleanly even when switching away from non-Google providers
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/calendar-settings.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/calendar-settings.tsx
@@ -4,20 +4,33 @@ import { useRouter } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Alert, Platform, StyleSheet, View } from "react-native";
+import {
+  Alert,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
 
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
+import {
+  ProfileSectionCard,
+  ProfileSectionHeader,
+} from "@/components/profile/profile-settings-sections";
+import { IconSymbol } from "@/components/ui/icon-symbol";
 import { ActionButton } from "@/components/ui/action-button";
 import {
-  KitList,
-  KitListItem,
-  KitSegmentedToggle,
-  KitSwitchRow,
-} from "@/components/ui/kit";
-import { BrandSpacing } from "@/constants/brand";
+  BrandRadius,
+  BrandSpacing,
+  BrandType,
+  type BrandPalette,
+} from "@/constants/brand";
 import { useUser } from "@/contexts/user-context";
 import { api } from "@/convex/_generated/api";
+import { useAppInsets } from "@/hooks/use-app-insets";
 import { useBrand } from "@/hooks/use-brand";
 import { prepareDeviceCalendarSync } from "@/lib/device-calendar-sync";
 
@@ -60,6 +73,15 @@ type DisconnectGoogleCalendarResult = {
   deletedRemoteEvents: boolean;
 };
 
+type ProviderOptionProps = {
+  value: CalendarProvider;
+  title: string;
+  description: string;
+  selected: boolean;
+  onPress: (value: CalendarProvider) => void;
+  palette: BrandPalette;
+};
+
 WebBrowser.maybeCompleteAuthSession();
 
 function resolveGoogleClientId() {
@@ -72,10 +94,146 @@ function resolveGoogleClientId() {
   return process.env.EXPO_PUBLIC_GOOGLE_CALENDAR_CLIENT_ID_WEB;
 }
 
+function StatusSignal({
+  label,
+  value,
+  palette,
+  tone = "surface",
+}: {
+  label: string;
+  value: string;
+  palette: BrandPalette;
+  tone?: "surface" | "accent";
+}) {
+  const backgroundColor =
+    tone === "accent"
+      ? (palette.primarySubtle as string)
+      : (palette.surfaceElevated as string);
+  const labelColor =
+    tone === "accent"
+      ? (palette.primary as string)
+      : (palette.textMuted as string);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        minWidth: 0,
+        gap: 2,
+        borderRadius: BrandRadius.card - 6,
+        borderCurve: "continuous",
+        backgroundColor,
+        paddingHorizontal: 14,
+        paddingVertical: 12,
+      }}
+    >
+      <Text
+        style={{
+          ...BrandType.micro,
+          color: labelColor,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        numberOfLines={1}
+        style={{
+          ...BrandType.bodyStrong,
+          color: palette.text as string,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function ProviderOption({
+  value,
+  title,
+  description,
+  selected,
+  onPress,
+  palette,
+}: ProviderOptionProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      onPress={() => onPress(value)}
+      style={({ pressed }) => ({
+        gap: 6,
+        borderWidth: 1,
+        borderRadius: BrandRadius.button,
+        borderCurve: "continuous",
+        borderColor: selected
+          ? (palette.primary as string)
+          : (palette.border as string),
+        backgroundColor: selected
+          ? (palette.primarySubtle as string)
+          : (palette.surfaceElevated as string),
+        paddingHorizontal: 14,
+        paddingVertical: 14,
+        opacity: pressed ? 0.9 : 1,
+      })}
+    >
+      <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
+        <View style={{ flex: 1, gap: 2, minWidth: 0 }}>
+          <Text
+            style={{
+              ...BrandType.bodyStrong,
+              color: palette.text as string,
+            }}
+          >
+            {title}
+          </Text>
+          <Text
+            style={{
+              ...BrandType.caption,
+              color: palette.textMuted as string,
+            }}
+          >
+            {description}
+          </Text>
+        </View>
+        <View
+          style={[
+            styles.providerBadge,
+            {
+              backgroundColor: selected
+                ? (palette.primary as string)
+                : (palette.surface as string),
+              borderColor: selected
+                ? (palette.primary as string)
+                : (palette.borderStrong as string),
+            },
+          ]}
+        >
+          <Text
+            style={{
+              ...BrandType.micro,
+              color: selected
+                ? (palette.onPrimary as string)
+                : (palette.textMuted as string),
+              letterSpacing: 0.6,
+              textTransform: "uppercase",
+            }}
+          >
+            {selected ? "Live" : "Pick"}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
 export default function CalendarSettingsScreen() {
   const { t, i18n } = useTranslation();
   const palette = useBrand();
   const router = useRouter();
+  const { overlayBottom } = useAppInsets();
   const { currentUser } = useUser();
 
   const instructorSettings = useQuery(
@@ -160,6 +318,63 @@ export default function CalendarSettingsScreen() {
   const hasChanges =
     provider !== (instructorSettings.calendarProvider ?? "none") ||
     syncEnabled !== (instructorSettings.calendarSyncEnabled ?? false);
+  const connectedDate = instructorSettings.calendarConnectedAt
+    ? new Date(instructorSettings.calendarConnectedAt).toLocaleDateString(
+        i18n.resolvedLanguage ?? "en",
+        { month: "short", day: "numeric", year: "numeric" },
+      )
+    : null;
+
+  const providerLabel = t(CALENDAR_PROVIDER_KEYS[provider]);
+  const syncStateLabel =
+    provider === "none"
+      ? t("profile.calendar.syncOff", { defaultValue: "Off" })
+      : syncEnabled
+        ? t("profile.calendar.syncOn", { defaultValue: "Auto-add on" })
+        : t("profile.calendar.syncManual", { defaultValue: "Manual" });
+  const heroTitle =
+    provider === "google"
+      ? hasGoogleConnection
+        ? t("profile.calendar.heroGoogleLive", {
+            defaultValue: "Google sync is live",
+          })
+        : t("profile.calendar.heroGooglePending", {
+            defaultValue: "Connect Google to go live",
+          })
+      : provider === "apple"
+        ? t("profile.calendar.heroApple", {
+            defaultValue: "Device calendar sync is ready",
+          })
+        : t("profile.calendar.heroOff", {
+            defaultValue: "Calendar sync is off",
+          });
+  const heroBody =
+    provider === "google"
+      ? hasGoogleConnection
+        ? t("profile.calendar.heroGoogleLiveBody", {
+            defaultValue:
+              "Accepted sessions can flow straight into your Google calendar with one active connection.",
+          })
+        : t("profile.calendar.heroGooglePendingBody", {
+            defaultValue:
+              "Pick Google, connect the account, then decide whether new sessions auto-land or stay manual.",
+          })
+      : provider === "apple"
+        ? t("profile.calendar.heroAppleBody", {
+            defaultValue:
+              "Queue writes accepted sessions into your device calendar after you grant local calendar access.",
+          })
+        : t("profile.calendar.heroOffBody", {
+            defaultValue:
+              "Leave sync off if you want Queue to stay separate from your personal scheduling stack.",
+          });
+
+  const handleProviderChange = (next: CalendarProvider) => {
+    setProvider(next);
+    if (next === "none") {
+      setSyncEnabled(false);
+    }
+  };
 
   const onSave = async () => {
     setIsSaving(true);
@@ -185,20 +400,14 @@ export default function CalendarSettingsScreen() {
         setSyncEnabled(nextSyncEnabled);
       }
 
-      let disconnectResult: DisconnectGoogleCalendarResult | null = null;
       if (switchingAwayFromGoogle) {
-        disconnectResult = await disconnectGoogleCalendar({});
+        const disconnectResult = await disconnectGoogleCalendar({});
         if (!disconnectResult.deletedRemoteEvents) {
           Alert.alert(
             t("profile.settings.calendar.disconnectCleanupWarningTitle"),
             t("profile.settings.calendar.disconnectCleanupWarningBody"),
           );
         }
-      }
-
-      if (provider === "none") {
-        router.back();
-        return;
       }
 
       await saveSettings({
@@ -282,134 +491,408 @@ export default function CalendarSettingsScreen() {
     }
   };
 
-  const connectedDate = instructorSettings.calendarConnectedAt
-    ? new Date(instructorSettings.calendarConnectedAt).toLocaleDateString(
-        i18n.resolvedLanguage ?? "en",
-        { month: "short", day: "numeric", year: "numeric" },
-      )
-    : null;
-
   return (
-    <TabScreenScrollView
-      routeKey="instructor/profile"
-      style={[styles.screen, { backgroundColor: palette.appBg }]}
-    >
-      <KitList inset>
-        <KitListItem title={t("profile.settings.calendar.provider.none")}>
-          <View style={{ marginTop: 8 }}>
-            <KitSegmentedToggle<CalendarProvider>
-              value={provider}
-              onChange={(next) => {
-                setProvider(next);
-                if (next === "none") setSyncEnabled(false);
-              }}
-              options={(
-                Object.keys(CALENDAR_PROVIDER_KEYS) as CalendarProvider[]
-              ).map((key) => ({
-                value: key,
-                label: t(CALENDAR_PROVIDER_KEYS[key]),
-              }))}
+    <View style={[styles.screen, { backgroundColor: palette.appBg }]}>
+      <TabScreenScrollView
+        routeKey="instructor/profile"
+        contentContainerStyle={{
+          paddingHorizontal: BrandSpacing.lg,
+          paddingTop: BrandSpacing.lg,
+          paddingBottom: 148,
+          gap: BrandSpacing.lg,
+        }}
+      >
+        <View
+          style={[
+            styles.heroCard,
+            {
+              backgroundColor: palette.surfaceAlt as string,
+              borderColor: palette.border as string,
+            },
+          ]}
+        >
+          <View style={styles.heroHeaderRow}>
+            <View style={styles.heroCopy}>
+              <Text
+                style={{
+                  ...BrandType.micro,
+                  color: palette.textMuted as string,
+                  letterSpacing: 0.8,
+                }}
+              >
+                {t("profile.settings.calendar.title").toUpperCase()}
+              </Text>
+              <Text
+                style={{
+                  ...BrandType.heading,
+                  color: palette.text as string,
+                }}
+              >
+                {heroTitle}
+              </Text>
+              <Text
+                style={{
+                  ...BrandType.body,
+                  color: palette.textMuted as string,
+                }}
+              >
+                {heroBody}
+              </Text>
+            </View>
+            <View
+              style={[
+                styles.heroIconWrap,
+                { backgroundColor: palette.primarySubtle as string },
+              ]}
+            >
+              <IconSymbol
+                name="calendar.badge.clock"
+                size={22}
+                color={palette.primary as string}
+              />
+            </View>
+          </View>
+
+          <View style={styles.heroSignalsRow}>
+            <StatusSignal
+              label={t("profile.calendar.signalProvider", {
+                defaultValue: "Provider",
+              })}
+              value={providerLabel}
+              palette={palette}
+              tone={provider === "none" ? "surface" : "accent"}
+            />
+            <StatusSignal
+              label={t("profile.calendar.signalSync", {
+                defaultValue: "Mode",
+              })}
+              value={syncStateLabel}
+              palette={palette}
             />
           </View>
-        </KitListItem>
-      </KitList>
+        </View>
 
-      <View style={{ paddingTop: 8 }}>
-        <KitList inset>
-          <KitSwitchRow
-            title={t("profile.settings.calendar.autoSync")}
-            value={syncEnabled}
-            disabled={
-              provider === "none" ||
-              (provider === "google" && !hasGoogleConnection)
-            }
-            onValueChange={setSyncEnabled}
-            description={t("profile.settings.calendar.futureNote")}
+        <View style={{ gap: BrandSpacing.sm }}>
+          <ProfileSectionHeader
+            label={t("profile.calendar.providerLabel", {
+              defaultValue: "Provider",
+            })}
+            description={t("profile.settings.calendar.description")}
+            icon="calendar.badge.clock"
+            palette={palette}
+            flush
           />
-          {provider === "google" ? (
-            <KitListItem
-              title={
-                hasGoogleConnection
-                  ? t("profile.settings.calendar.googleConnectedAs", {
-                      email: googleStatus?.accountEmail ?? "Google account",
-                    })
-                  : t("profile.settings.calendar.googleConnectRequired")
-              }
-            />
-          ) : null}
-          {provider === "apple" ? (
-            <KitListItem
-              title={t("profile.settings.calendar.applePermissionNote")}
-            />
-          ) : null}
-          {provider === "google" && googleStatus?.lastError ? (
-            <KitListItem title={googleStatus.lastError} />
-          ) : null}
-          {connectedDate ? (
-            <KitListItem
-              title={t("profile.settings.calendar.lastConnected", {
-                date: connectedDate,
-              })}
-            />
-          ) : null}
-        </KitList>
-      </View>
+          <ProfileSectionCard palette={palette} style={{ marginHorizontal: 0 }}>
+            <View style={styles.sectionBody}>
+              <ProviderOption
+                value="none"
+                title={t(CALENDAR_PROVIDER_KEYS.none)}
+                description={t("profile.calendar.providerNoneBody", {
+                  defaultValue:
+                    "Keep Queue self-contained and skip calendar export entirely.",
+                })}
+                selected={provider === "none"}
+                onPress={handleProviderChange}
+                palette={palette}
+              />
+              <ProviderOption
+                value="google"
+                title={t(CALENDAR_PROVIDER_KEYS.google)}
+                description={t("profile.calendar.providerGoogleBody", {
+                  defaultValue:
+                    "Push accepted sessions into the connected Google calendar account.",
+                })}
+                selected={provider === "google"}
+                onPress={handleProviderChange}
+                palette={palette}
+              />
+              <ProviderOption
+                value="apple"
+                title={t(CALENDAR_PROVIDER_KEYS.apple)}
+                description={t("profile.calendar.providerAppleBody", {
+                  defaultValue:
+                    "Write accepted sessions into the device calendar on this phone.",
+                })}
+                selected={provider === "apple"}
+                onPress={handleProviderChange}
+                palette={palette}
+              />
+            </View>
+          </ProfileSectionCard>
+        </View>
+
+        <View style={{ gap: BrandSpacing.sm }}>
+          <ProfileSectionHeader
+            label={t("profile.calendar.commandLabel", {
+              defaultValue: "Command",
+            })}
+            description={t("profile.calendar.commandBody", {
+              defaultValue:
+                "Choose whether accepted sessions auto-land in your calendar or stay available for manual sync.",
+            })}
+            icon="sparkles"
+            palette={palette}
+            flush
+          />
+          <ProfileSectionCard palette={palette} style={{ marginHorizontal: 0 }}>
+            <View style={styles.sectionBody}>
+              <View
+                style={[
+                  styles.toggleRow,
+                  {
+                    borderColor: palette.border as string,
+                    backgroundColor: palette.surfaceElevated as string,
+                  },
+                ]}
+              >
+                <View style={{ flex: 1, gap: 4, minWidth: 0 }}>
+                  <Text
+                    style={{
+                      ...BrandType.bodyStrong,
+                      color: palette.text as string,
+                    }}
+                  >
+                    {t("profile.settings.calendar.autoSync")}
+                  </Text>
+                  <Text
+                    style={{
+                      ...BrandType.caption,
+                      color: palette.textMuted as string,
+                    }}
+                  >
+                    {t("profile.settings.calendar.futureNote")}
+                  </Text>
+                </View>
+                <Switch
+                  value={syncEnabled}
+                  onValueChange={setSyncEnabled}
+                  disabled={
+                    provider === "none" ||
+                    (provider === "google" && !hasGoogleConnection)
+                  }
+                  trackColor={{
+                    false: palette.borderStrong as string,
+                    true: palette.primary as string,
+                  }}
+                  thumbColor={palette.surfaceElevated as string}
+                  ios_backgroundColor={palette.borderStrong as string}
+                />
+              </View>
+
+              {provider === "google" ? (
+                <View
+                  style={[
+                    styles.infoCard,
+                    {
+                      borderColor: hasGoogleConnection
+                        ? (palette.primary as string)
+                        : (palette.border as string),
+                      backgroundColor: hasGoogleConnection
+                        ? (palette.primarySubtle as string)
+                        : (palette.surfaceElevated as string),
+                    },
+                  ]}
+                >
+                  <Text
+                    style={{
+                      ...BrandType.micro,
+                      color: hasGoogleConnection
+                        ? (palette.primary as string)
+                        : (palette.textMuted as string),
+                      letterSpacing: 0.6,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {hasGoogleConnection
+                      ? t("profile.calendar.googleStateLive", {
+                          defaultValue: "Google linked",
+                        })
+                      : t("profile.calendar.googleStatePending", {
+                          defaultValue: "Google pending",
+                        })}
+                  </Text>
+                  <Text
+                    style={{
+                      ...BrandType.title,
+                      color: palette.text as string,
+                    }}
+                  >
+                    {hasGoogleConnection
+                      ? t("profile.settings.calendar.googleConnectedAs", {
+                          email: googleStatus?.accountEmail ?? "Google account",
+                        })
+                      : t("profile.settings.calendar.googleConnectRequired")}
+                  </Text>
+                  {connectedDate ? (
+                    <Text
+                      style={{
+                        ...BrandType.caption,
+                        color: palette.textMuted as string,
+                      }}
+                    >
+                      {t("profile.settings.calendar.lastConnected", {
+                        date: connectedDate,
+                      })}
+                    </Text>
+                  ) : null}
+                </View>
+              ) : null}
+
+              {provider === "apple" ? (
+                <View
+                  style={[
+                    styles.infoCard,
+                    {
+                      borderColor: palette.border as string,
+                      backgroundColor: palette.surfaceElevated as string,
+                    },
+                  ]}
+                >
+                  <Text
+                    style={{
+                      ...BrandType.micro,
+                      color: palette.textMuted as string,
+                      letterSpacing: 0.6,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {t("profile.calendar.appleLabel", {
+                      defaultValue: "Apple calendar",
+                    })}
+                  </Text>
+                  <Text
+                    style={{
+                      ...BrandType.title,
+                      color: palette.text as string,
+                    }}
+                  >
+                    {t("profile.settings.calendar.applePermissionNote")}
+                  </Text>
+                </View>
+              ) : null}
+
+              {provider === "none" ? (
+                <View
+                  style={[
+                    styles.infoCard,
+                    {
+                      borderColor: palette.border as string,
+                      backgroundColor: palette.surfaceElevated as string,
+                    },
+                  ]}
+                >
+                  <Text
+                    style={{
+                      ...BrandType.micro,
+                      color: palette.textMuted as string,
+                      letterSpacing: 0.6,
+                      textTransform: "uppercase",
+                    }}
+                  >
+                    {t("profile.calendar.noneLabel", {
+                      defaultValue: "No sync",
+                    })}
+                  </Text>
+                  <Text
+                    style={{
+                      ...BrandType.title,
+                      color: palette.text as string,
+                    }}
+                  >
+                    {t("profile.calendar.noneBody", {
+                      defaultValue:
+                        "Queue will track accepted sessions internally without writing into an external calendar.",
+                    })}
+                  </Text>
+                </View>
+              ) : null}
+
+              {googleStatus?.lastError ? (
+                <View
+                  style={[
+                    styles.errorCard,
+                    {
+                      borderColor: palette.danger as string,
+                      backgroundColor: palette.dangerSubtle as string,
+                    },
+                  ]}
+                >
+                  <Text
+                    style={{
+                      ...BrandType.bodyMedium,
+                      color: palette.danger as string,
+                    }}
+                  >
+                    {googleStatus.lastError}
+                  </Text>
+                </View>
+              ) : null}
+
+              {provider === "google" ? (
+                <View style={{ gap: 10 }}>
+                  {!hasGoogleConnection ? (
+                    <ActionButton
+                      label={
+                        isConnectingGoogle
+                          ? t("profile.settings.actions.connecting")
+                          : t("profile.settings.calendar.actions.connectGoogle")
+                      }
+                      onPress={() => {
+                        void onConnectGoogle();
+                      }}
+                      disabled={
+                        isConnectingGoogle || !googleClientId || !googleRequest
+                      }
+                      palette={palette}
+                      fullWidth
+                    />
+                  ) : (
+                    <>
+                      <ActionButton
+                        label={
+                          isSyncingGoogle
+                            ? t("profile.settings.actions.syncing")
+                            : t("profile.settings.calendar.actions.syncNow")
+                        }
+                        onPress={() => {
+                          void onSyncGoogleNow();
+                        }}
+                        disabled={isSyncingGoogle}
+                        palette={palette}
+                        fullWidth
+                      />
+                      <ActionButton
+                        label={
+                          isDisconnectingGoogle
+                            ? t("profile.settings.actions.disconnecting")
+                            : t("profile.settings.calendar.actions.disconnectGoogle")
+                        }
+                        onPress={() => {
+                          void onDisconnectGoogle();
+                        }}
+                        disabled={isDisconnectingGoogle}
+                        palette={palette}
+                        tone="secondary"
+                        fullWidth
+                      />
+                    </>
+                  )}
+                </View>
+              ) : null}
+            </View>
+          </ProfileSectionCard>
+        </View>
+      </TabScreenScrollView>
 
       <View
-        style={{ paddingHorizontal: 16, paddingTop: BrandSpacing.md, gap: 10 }}
+        style={[
+          styles.actionRail,
+          {
+            bottom: overlayBottom,
+            backgroundColor: palette.appBg as string,
+          },
+        ]}
       >
-        {provider === "google" ? (
-          <View style={{ gap: 10 }}>
-            {!hasGoogleConnection ? (
-              <ActionButton
-                label={
-                  isConnectingGoogle
-                    ? t("profile.settings.actions.connecting")
-                    : t("profile.settings.calendar.actions.connectGoogle")
-                }
-                onPress={() => {
-                  void onConnectGoogle();
-                }}
-                disabled={
-                  isConnectingGoogle || !googleClientId || !googleRequest
-                }
-                palette={palette}
-                fullWidth
-              />
-            ) : (
-              <>
-                <ActionButton
-                  label={
-                    isSyncingGoogle
-                      ? t("profile.settings.actions.syncing")
-                      : t("profile.settings.calendar.actions.syncNow")
-                  }
-                  onPress={() => {
-                    void onSyncGoogleNow();
-                  }}
-                  disabled={isSyncingGoogle}
-                  palette={palette}
-                  fullWidth
-                />
-                <ActionButton
-                  label={
-                    isDisconnectingGoogle
-                      ? t("profile.settings.actions.disconnecting")
-                      : t("profile.settings.calendar.actions.disconnectGoogle")
-                  }
-                  onPress={() => {
-                    void onDisconnectGoogle();
-                  }}
-                  disabled={isDisconnectingGoogle}
-                  palette={palette}
-                  tone="secondary"
-                  fullWidth
-                />
-              </>
-            )}
-          </View>
-        ) : null}
-
         <ActionButton
           label={
             isSaving
@@ -431,12 +914,85 @@ export default function CalendarSettingsScreen() {
           fullWidth
         />
       </View>
-    </TabScreenScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   screen: {
     flex: 1,
+  },
+  heroCard: {
+    gap: BrandSpacing.lg,
+    borderWidth: 1,
+    borderRadius: BrandRadius.card,
+    borderCurve: "continuous",
+    padding: BrandSpacing.xl,
+  },
+  heroHeaderRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: BrandSpacing.md,
+  },
+  heroCopy: {
+    flex: 1,
+    gap: 6,
+    minWidth: 0,
+  },
+  heroIconWrap: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    borderCurve: "continuous",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  heroSignalsRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  sectionBody: {
+    padding: BrandSpacing.lg,
+    gap: BrandSpacing.md,
+  },
+  providerBadge: {
+    minWidth: 52,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderRadius: BrandRadius.pill,
+    borderCurve: "continuous",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: BrandSpacing.md,
+    borderWidth: 1,
+    borderRadius: BrandRadius.button,
+    borderCurve: "continuous",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  infoCard: {
+    gap: 6,
+    borderWidth: 1,
+    borderRadius: BrandRadius.card - 4,
+    borderCurve: "continuous",
+    padding: BrandSpacing.lg,
+  },
+  errorCard: {
+    borderWidth: 1,
+    borderRadius: BrandRadius.button,
+    borderCurve: "continuous",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  actionRail: {
+    position: "absolute",
+    left: BrandSpacing.lg,
+    right: BrandSpacing.lg,
+    gap: 10,
   },
 });


### PR DESCRIPTION
## Summary
- redesign the instructor calendar settings page into a provider-first operations surface
- remove the remaining kit segmented/list shell from that route
- fix the no-sync save path so switching away from non-Google providers persists cleanly

## Validation
- bun run typecheck