### PR TITLE
UI Redesign 04: normalize sports board

### DIFF
--- a/docs/ui-ux-brutal-audit-2026-03-13.md
+++ b/docs/ui-ux-brutal-audit-2026-03-13.md
@@ -598,6 +598,12 @@ Replace with consequence and momentum:
 - removed the remaining `KitList`, `KitSegmentedToggle`, and `KitSwitchRow` shell from the route in favor of shared profile cards and direct provider actions
 - fixed the save flow so choosing `No sync` persists cleanly even when switching away from non-Google providers
 
+### Slice 20
+
+- rebuilt the instructor sports route into a dedicated board editor instead of a caption plus nested card editor
+- added a content-only selector mode so the route no longer stacks redundant edit chrome inside a dedicated editing page
+- kept the sports selection surface on shared semantic tokens while tightening the hierarchy and save flow
+
 ## Final Verdict
 
 The app is not ugly.

--- a/src/app/(app)/(instructor-tabs)/instructor/profile/sports.tsx
+++ b/src/app/(app)/(instructor-tabs)/instructor/profile/sports.tsx
@@ -3,17 +3,83 @@ import * as Haptics from "expo-haptics";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
+
 import { TabScreenScrollView } from "@/components/layout/tab-screen-scroll-view";
 import { LoadingScreen } from "@/components/loading-screen";
+import {
+  ProfileSectionCard,
+  ProfileSectionHeader,
+} from "@/components/profile/profile-settings-sections";
 import { SportsMultiSelect } from "@/components/profile/sports-multi-select";
-import { ThemedText } from "@/components/themed-text";
+import { IconSymbol } from "@/components/ui/icon-symbol";
 import { ActionButton } from "@/components/ui/action-button";
-import { BrandSpacing } from "@/constants/brand";
+import {
+  BrandRadius,
+  BrandSpacing,
+  BrandType,
+  type BrandPalette,
+} from "@/constants/brand";
 import { useUser } from "@/contexts/user-context";
 import { api } from "@/convex/_generated/api";
 import { useAppInsets } from "@/hooks/use-app-insets";
 import { useBrand } from "@/hooks/use-brand";
+
+function StatusSignal({
+  label,
+  value,
+  palette,
+  tone = "surface",
+}: {
+  label: string;
+  value: string;
+  palette: BrandPalette;
+  tone?: "surface" | "accent";
+}) {
+  const backgroundColor =
+    tone === "accent"
+      ? (palette.primarySubtle as string)
+      : (palette.surfaceElevated as string);
+  const labelColor =
+    tone === "accent"
+      ? (palette.primary as string)
+      : (palette.textMuted as string);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        minWidth: 0,
+        gap: 2,
+        borderRadius: BrandRadius.card - 6,
+        borderCurve: "continuous",
+        backgroundColor,
+        paddingHorizontal: 14,
+        paddingVertical: 12,
+      }}
+    >
+      <Text
+        style={{
+          ...BrandType.micro,
+          color: labelColor,
+          letterSpacing: 0.6,
+          textTransform: "uppercase",
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        numberOfLines={1}
+        style={{
+          ...BrandType.bodyStrong,
+          color: palette.text as string,
+        }}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
 
 export default function SportsScreen() {
   const { t } = useTranslation();
@@ -56,14 +122,40 @@ export default function SportsScreen() {
   };
 
   const hasChanges = (() => {
-    if (draft === null) return false;
+    if (draft === null) {
+      return false;
+    }
     const sorted = [...draft].sort();
     const serverSorted = [...serverSports].sort();
     return JSON.stringify(sorted) !== JSON.stringify(serverSorted);
   })();
 
+  const heroTitle =
+    sports.length > 0
+      ? t("profile.sports.heroReady", {
+          count: sports.length,
+          defaultValue: `You are live in ${String(sports.length)} sports`,
+        })
+      : t("profile.sports.heroEmpty", {
+          defaultValue: "Build the sports board you want jobs from",
+        });
+  const heroBody =
+    sports.length > 0
+      ? t("profile.sports.heroReadyBody", {
+          defaultValue:
+            "Keep the board tight. Every selected sport sharpens matching, profile clarity, and job quality.",
+        })
+      : t("profile.sports.heroEmptyBody", {
+          defaultValue:
+            "Select the sports you actually teach so Queue stops looking broad and starts looking credible.",
+        });
+
   const onSave = async () => {
-    if (!hasChanges || !draft) return;
+    if (!hasChanges || !draft) {
+      router.back();
+      return;
+    }
+
     setIsSaving(true);
     setErrorMessage(null);
     try {
@@ -102,51 +194,172 @@ export default function SportsScreen() {
       <TabScreenScrollView
         routeKey="instructor/profile"
         contentContainerStyle={{
-          padding: 16,
-          paddingBottom: hasChanges ? 120 : 100,
-          gap: 12,
+          paddingHorizontal: BrandSpacing.lg,
+          paddingTop: BrandSpacing.lg,
+          paddingBottom: 148,
+          gap: BrandSpacing.lg,
         }}
       >
-        <ThemedText type="caption" style={{ color: palette.textMuted }}>
-          {sports.length > 0
-            ? t("profile.settings.sports.selected", { count: sports.length })
-            : t("profile.settings.sports.description")}
-        </ThemedText>
-        <SportsMultiSelect
-          palette={palette}
-          selectedSports={sports}
-          onToggleSport={toggleSport}
-          searchPlaceholder={t("profile.settings.sports.searchPlaceholder")}
-          title={t("profile.settings.sports.title")}
-          emptyHint={t("profile.settings.sports.none")}
-          defaultOpen
-        />
+        <View
+          style={[
+            styles.heroCard,
+            {
+              backgroundColor: palette.surfaceAlt as string,
+              borderColor: palette.border as string,
+            },
+          ]}
+        >
+          <View style={styles.heroHeaderRow}>
+            <View style={styles.heroCopy}>
+              <Text
+                style={{
+                  ...BrandType.micro,
+                  color: palette.textMuted as string,
+                  letterSpacing: 0.8,
+                }}
+              >
+                {t("profile.settings.sports.title").toUpperCase()}
+              </Text>
+              <Text
+                style={{
+                  ...BrandType.heading,
+                  color: palette.text as string,
+                }}
+              >
+                {heroTitle}
+              </Text>
+              <Text
+                style={{
+                  ...BrandType.body,
+                  color: palette.textMuted as string,
+                }}
+              >
+                {heroBody}
+              </Text>
+            </View>
+            <View
+              style={[
+                styles.heroIconWrap,
+                { backgroundColor: palette.primarySubtle as string },
+              ]}
+            >
+              <IconSymbol
+                name="sparkles"
+                size={22}
+                color={palette.primary as string}
+              />
+            </View>
+          </View>
+
+          <View style={styles.heroSignalsRow}>
+            <StatusSignal
+              label={t("profile.sports.signalSelected", {
+                defaultValue: "Selected",
+              })}
+              value={t("profile.settings.sports.selected", {
+                count: sports.length,
+              })}
+              palette={palette}
+              tone="accent"
+            />
+            <StatusSignal
+              label={t("profile.sports.signalState", {
+                defaultValue: "State",
+              })}
+              value={
+                hasChanges
+                  ? t("profile.sports.stateUnsaved", {
+                      defaultValue: "Unsaved changes",
+                    })
+                  : t("profile.sports.stateLive", {
+                      defaultValue: "Live",
+                    })
+              }
+              palette={palette}
+            />
+          </View>
+        </View>
+
+        <View style={{ gap: BrandSpacing.sm }}>
+          <ProfileSectionHeader
+            label={t("profile.sports.boardLabel", {
+              defaultValue: "Sports board",
+            })}
+            description={t("profile.sports.boardBody", {
+              defaultValue:
+                "Tap to add or remove. Keep it honest and tight so the matching engine stays sharp.",
+            })}
+            icon="sparkles"
+            palette={palette}
+            flush
+          />
+          <ProfileSectionCard palette={palette} style={{ marginHorizontal: 0 }}>
+            <SportsMultiSelect
+              palette={palette}
+              selectedSports={sports}
+              onToggleSport={toggleSport}
+              searchPlaceholder={t("profile.settings.sports.searchPlaceholder")}
+              title={t("profile.settings.sports.title")}
+              emptyHint={t("profile.settings.sports.none")}
+              defaultOpen
+              variant="content"
+            />
+          </ProfileSectionCard>
+        </View>
+
         {errorMessage ? (
-          <ThemedText selectable style={{ color: palette.danger }}>
-            {errorMessage}
-          </ThemedText>
+          <View
+            style={[
+              styles.errorCard,
+              {
+                borderColor: palette.danger as string,
+                backgroundColor: palette.dangerSubtle as string,
+              },
+            ]}
+          >
+            <Text
+              selectable
+              style={{
+                ...BrandType.bodyMedium,
+                color: palette.danger as string,
+              }}
+            >
+              {errorMessage}
+            </Text>
+          </View>
         ) : null}
-        <View style={{ height: BrandSpacing.md }} />
       </TabScreenScrollView>
 
-      {/* Save FAB */}
-      {hasChanges ? (
-        <View style={[styles.saveFabArea, { bottom: overlayBottom }]}>
-          <ActionButton
-            label={
-              isSaving
-                ? t("profile.settings.actions.saving")
-                : t("profile.settings.actions.save")
-            }
-            onPress={() => {
-              void onSave();
-            }}
-            disabled={isSaving}
-            palette={palette}
-            fullWidth
-          />
-        </View>
-      ) : null}
+      <View
+        style={[
+          styles.actionRail,
+          {
+            bottom: overlayBottom,
+            backgroundColor: palette.appBg as string,
+          },
+        ]}
+      >
+        <ActionButton
+          label={
+            isSaving
+              ? t("profile.settings.actions.saving")
+              : t("profile.settings.actions.save")
+          }
+          onPress={() => {
+            void onSave();
+          }}
+          disabled={isSaving || !hasChanges}
+          palette={palette}
+          fullWidth
+        />
+        <ActionButton
+          label={t("common.cancel")}
+          onPress={() => router.back()}
+          palette={palette}
+          tone="secondary"
+          fullWidth
+        />
+      </View>
     </View>
   );
 }
@@ -155,10 +368,46 @@ const styles = StyleSheet.create({
   screen: {
     flex: 1,
   },
-  saveFabArea: {
+  heroCard: {
+    gap: BrandSpacing.lg,
+    borderWidth: 1,
+    borderRadius: BrandRadius.card,
+    borderCurve: "continuous",
+    padding: BrandSpacing.xl,
+  },
+  heroHeaderRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: BrandSpacing.md,
+  },
+  heroCopy: {
+    flex: 1,
+    gap: 6,
+    minWidth: 0,
+  },
+  heroIconWrap: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    borderCurve: "continuous",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  heroSignalsRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  errorCard: {
+    borderWidth: 1,
+    borderRadius: BrandRadius.button,
+    borderCurve: "continuous",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  actionRail: {
     position: "absolute",
-    left: 16,
-    right: 16,
-    zIndex: 20,
+    left: BrandSpacing.lg,
+    right: BrandSpacing.lg,
+    gap: 10,
   },
 });

--- a/src/components/profile/sports-multi-select.tsx
+++ b/src/components/profile/sports-multi-select.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { ThemedText } from "@/components/themed-text";
 import { IconSymbol } from "@/components/ui/icon-symbol";
@@ -15,6 +16,7 @@ type SportsMultiSelectProps = {
   title: string;
   emptyHint: string;
   defaultOpen?: boolean;
+  variant?: "card" | "content";
 };
 
 export function SportsMultiSelect({
@@ -25,9 +27,12 @@ export function SportsMultiSelect({
   title,
   emptyHint,
   defaultOpen = false,
+  variant = "card",
 }: SportsMultiSelectProps) {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
+  const isCardVariant = variant === "card";
 
   const filteredSports = useMemo(() => {
     const normalized = query.trim().toLowerCase();
@@ -46,6 +51,156 @@ export function SportsMultiSelect({
     () => filteredSports.filter((sport) => !selectedSports.includes(sport)),
     [filteredSports, selectedSports],
   );
+
+  const panel = (
+    <View
+      style={[styles.panel, isCardVariant ? null : styles.panelContentOnly]}
+    >
+      <NativeSearchField
+        value={query}
+        onChangeText={setQuery}
+        placeholder={searchPlaceholder}
+      />
+      {selectedSportsList.length > 0 ? (
+        <View style={styles.section}>
+          <Text
+            style={[
+              styles.sectionLabel,
+              { color: palette.textMuted as string },
+            ]}
+          >
+            {t("profile.sports.selectedLabel", {
+              defaultValue: "Selected sports",
+            })}
+          </Text>
+          <View style={styles.resultsList}>
+            {selectedSportsList.map((sport) => (
+              <Pressable
+                key={`selected-${sport}`}
+                accessibilityRole="button"
+                onPress={() => onToggleSport(sport)}
+                style={({ pressed }) => [
+                  styles.resultRow,
+                  {
+                    backgroundColor: palette.primarySubtle as string,
+                    opacity: pressed ? 0.82 : 1,
+                  },
+                ]}
+              >
+                <View style={{ flex: 1, gap: 2 }}>
+                  <Text
+                    style={[
+                      styles.resultTitle,
+                      { color: palette.text as string },
+                    ]}
+                  >
+                    {isSportType(sport) ? toSportLabel(sport) : sport}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.resultMeta,
+                      { color: palette.primary as string },
+                    ]}
+                  >
+                    {t("profile.sports.selectedBody", {
+                      defaultValue: "Added to your teaching profile",
+                    })}
+                  </Text>
+                </View>
+                <IconSymbol
+                  name="checkmark.circle.fill"
+                  size={18}
+                  color={palette.primary as string}
+                />
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      ) : null}
+      <View style={styles.section}>
+        <Text
+          style={[styles.sectionLabel, { color: palette.textMuted as string }]}
+        >
+          {query.trim().length > 0
+            ? t("profile.sports.matchingLabel", {
+                defaultValue: "Matching sports",
+              })
+            : t("profile.sports.allLabel", {
+                defaultValue: "All sports",
+              })}
+        </Text>
+        <ScrollView
+          nestedScrollEnabled
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.resultsList}
+          style={styles.resultsViewport}
+        >
+          {availableSportsList.length > 0 ? (
+            availableSportsList.map((sport) => (
+              <Pressable
+                key={sport}
+                accessibilityRole="button"
+                onPress={() => onToggleSport(sport)}
+                style={({ pressed }) => [
+                  styles.resultRow,
+                  {
+                    backgroundColor: palette.surface as string,
+                    opacity: pressed ? 0.82 : 1,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.resultTitle,
+                    { color: palette.text as string },
+                  ]}
+                >
+                  {toSportLabel(sport)}
+                </Text>
+                <IconSymbol
+                  name="plus.circle.fill"
+                  size={18}
+                  color={palette.textMuted as string}
+                />
+              </Pressable>
+            ))
+          ) : (
+            <View
+              style={[
+                styles.emptyState,
+                {
+                  backgroundColor: palette.surface as string,
+                  borderColor: palette.border as string,
+                },
+              ]}
+            >
+              <Text
+                style={[styles.resultTitle, { color: palette.text as string }]}
+              >
+                {t("profile.sports.emptyTitle", {
+                  defaultValue: "No matching sports",
+                })}
+              </Text>
+              <Text
+                style={[
+                  styles.resultMeta,
+                  { color: palette.textMuted as string },
+                ]}
+              >
+                {t("profile.sports.emptyBody", {
+                  defaultValue: "Try a different sport name.",
+                })}
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      </View>
+    </View>
+  );
+
+  if (!isCardVariant) {
+    return panel;
+  }
 
   return (
     <View
@@ -93,146 +248,14 @@ export function SportsMultiSelect({
               includeFontPadding: false,
             }}
           >
-            {isOpen ? "Done" : "Edit"}
+            {isOpen
+              ? t("profile.sports.done", { defaultValue: "Done" })
+              : t("profile.sports.edit", { defaultValue: "Edit" })}
           </Text>
         </View>
       </Pressable>
 
-      {isOpen ? (
-        <View style={styles.panel}>
-          <NativeSearchField
-            value={query}
-            onChangeText={setQuery}
-            placeholder={searchPlaceholder}
-          />
-          {selectedSportsList.length > 0 ? (
-            <View style={styles.section}>
-              <Text
-                style={[
-                  styles.sectionLabel,
-                  { color: palette.textMuted as string },
-                ]}
-              >
-                Selected sports
-              </Text>
-              <View style={styles.resultsList}>
-                {selectedSportsList.map((sport) => (
-                  <Pressable
-                    key={`selected-${sport}`}
-                    accessibilityRole="button"
-                    onPress={() => onToggleSport(sport)}
-                    style={({ pressed }) => [
-                      styles.resultRow,
-                      {
-                        backgroundColor: palette.primarySubtle as string,
-                        opacity: pressed ? 0.82 : 1,
-                      },
-                    ]}
-                  >
-                    <View style={{ flex: 1, gap: 2 }}>
-                      <Text
-                        style={[
-                          styles.resultTitle,
-                          { color: palette.text as string },
-                        ]}
-                      >
-                        {isSportType(sport) ? toSportLabel(sport) : sport}
-                      </Text>
-                      <Text
-                        style={[
-                          styles.resultMeta,
-                          { color: palette.primary as string },
-                        ]}
-                      >
-                        Added to your teaching profile
-                      </Text>
-                    </View>
-                    <IconSymbol
-                      name="checkmark.circle.fill"
-                      size={18}
-                      color={palette.primary as string}
-                    />
-                  </Pressable>
-                ))}
-              </View>
-            </View>
-          ) : null}
-          <View style={styles.section}>
-            <Text
-              style={[
-                styles.sectionLabel,
-                { color: palette.textMuted as string },
-              ]}
-            >
-              {query.trim().length > 0 ? "Matching sports" : "All sports"}
-            </Text>
-            <ScrollView
-              nestedScrollEnabled
-              showsVerticalScrollIndicator={false}
-              contentContainerStyle={styles.resultsList}
-              style={styles.resultsViewport}
-            >
-              {availableSportsList.length > 0 ? (
-                availableSportsList.map((sport) => (
-                  <Pressable
-                    key={sport}
-                    accessibilityRole="button"
-                    onPress={() => onToggleSport(sport)}
-                    style={({ pressed }) => [
-                      styles.resultRow,
-                      {
-                        backgroundColor: palette.surface as string,
-                        opacity: pressed ? 0.82 : 1,
-                      },
-                    ]}
-                  >
-                    <Text
-                      style={[
-                        styles.resultTitle,
-                        { color: palette.text as string },
-                      ]}
-                    >
-                      {toSportLabel(sport)}
-                    </Text>
-                    <IconSymbol
-                      name="plus.circle.fill"
-                      size={18}
-                      color={palette.textMuted as string}
-                    />
-                  </Pressable>
-                ))
-              ) : (
-                <View
-                  style={[
-                    styles.emptyState,
-                    {
-                      backgroundColor: palette.surface as string,
-                      borderColor: palette.border as string,
-                    },
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.resultTitle,
-                      { color: palette.text as string },
-                    ]}
-                  >
-                    No matching sports
-                  </Text>
-                  <Text
-                    style={[
-                      styles.resultMeta,
-                      { color: palette.textMuted as string },
-                    ]}
-                  >
-                    Try a different sport name.
-                  </Text>
-                </View>
-              )}
-            </ScrollView>
-          </View>
-        </View>
-      ) : null}
+      {isOpen ? panel : null}
     </View>
   );
 }
@@ -266,6 +289,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingBottom: 14,
     gap: 12,
+  },
+  panelContentOnly: {
+    paddingHorizontal: 0,
+    paddingBottom: 0,
   },
   section: {
     gap: 8,


### PR DESCRIPTION
## Summary
- redesign the instructor sports route into a dedicated board editor
- add a content-only sports selector mode to remove redundant nested edit chrome
- keep the route on semantic tokens with a stronger hierarchy and fixed action rail

## Validation
- bun run typecheck